### PR TITLE
Save full caller-saved state in EL1 IRQ stub

### DIFF
--- a/boot/vectors.S
+++ b/boot/vectors.S
@@ -41,11 +41,61 @@ __vec_base:
   .balign 0x80
   b .
 
+  .equ IRQ_FRAME_SIZE, 192
+  .equ IRQ_FRAME_X0, 0
+  .equ IRQ_FRAME_X2, 16
+  .equ IRQ_FRAME_X4, 32
+  .equ IRQ_FRAME_X6, 48
+  .equ IRQ_FRAME_X8, 64
+  .equ IRQ_FRAME_X10, 80
+  .equ IRQ_FRAME_X12, 96
+  .equ IRQ_FRAME_X14, 112
+  .equ IRQ_FRAME_X16, 128
+  .equ IRQ_FRAME_X18, 144
+  .equ IRQ_FRAME_LR, 152
+  .equ IRQ_FRAME_SP, 160
+  .equ IRQ_FRAME_SPSR, 168
+  .equ IRQ_FRAME_ELR, 176
+
   .global irq_el1
 irq_el1:
-  stp x0, x1, [sp, #-16]!
-  stp x2, x3, [sp, #-16]!
+  sub sp, sp, #IRQ_FRAME_SIZE
+  stp x0, x1, [sp, #IRQ_FRAME_X0]
+  stp x2, x3, [sp, #IRQ_FRAME_X2]
+  stp x4, x5, [sp, #IRQ_FRAME_X4]
+  stp x6, x7, [sp, #IRQ_FRAME_X6]
+  stp x8, x9, [sp, #IRQ_FRAME_X8]
+  stp x10, x11, [sp, #IRQ_FRAME_X10]
+  stp x12, x13, [sp, #IRQ_FRAME_X12]
+  stp x14, x15, [sp, #IRQ_FRAME_X14]
+  stp x16, x17, [sp, #IRQ_FRAME_X16]
+  str x18, [sp, #IRQ_FRAME_X18]
+  str x30, [sp, #IRQ_FRAME_LR]
+  add x18, sp, #IRQ_FRAME_SIZE
+  str x18, [sp, #IRQ_FRAME_SP]
+  mrs x18, spsr_el1
+  str x18, [sp, #IRQ_FRAME_SPSR]
+  mrs x18, elr_el1
+  str x18, [sp, #IRQ_FRAME_ELR]
+  // TODO: spill q0–q7 once SIMD is enabled.
+  mov x0, sp
   bl irq_handler_el1
-  ldp x2, x3, [sp], #16
-  ldp x0, x1, [sp], #16
+  mov x9, sp
+  ldr x16, [x9, #IRQ_FRAME_SP]
+  ldr x17, [x9, #IRQ_FRAME_SPSR]
+  ldr x18, [x9, #IRQ_FRAME_ELR]
+  msr elr_el1, x18
+  msr spsr_el1, x17
+  mov sp, x16
+  ldp x0, x1, [x9, #IRQ_FRAME_X0]
+  ldp x2, x3, [x9, #IRQ_FRAME_X2]
+  ldp x4, x5, [x9, #IRQ_FRAME_X4]
+  ldp x6, x7, [x9, #IRQ_FRAME_X6]
+  ldp x10, x11, [x9, #IRQ_FRAME_X10]
+  ldp x12, x13, [x9, #IRQ_FRAME_X12]
+  ldp x14, x15, [x9, #IRQ_FRAME_X14]
+  ldp x16, x17, [x9, #IRQ_FRAME_X16]
+  ldr x18, [x9, #IRQ_FRAME_X18]
+  ldr x30, [x9, #IRQ_FRAME_LR]
+  ldp x8, x9, [x9, #IRQ_FRAME_X8]
   eret

--- a/include/arch/irq.h
+++ b/include/arch/irq.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <stdint.h>
+
+struct irq_frame {
+  uint64_t regs[19];      // x0–x18
+  uint64_t lr;            // x30
+  uint64_t sp;            // pre-interrupt SP
+  uint64_t spsr;          // saved program status
+  uint64_t elr;           // return address
+  uint64_t reserved;      // keeps the frame 16-byte aligned (future SIMD spill)
+};

--- a/include/irq.h
+++ b/include/irq.h
@@ -1,8 +1,10 @@
 #pragma once
+#include "arch/irq.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-void irq_handler_el1(void);
+void irq_handler_el1(struct irq_frame* frame);
 #ifdef __cplusplus
 }
 #endif

--- a/src/irq.cc
+++ b/src/irq.cc
@@ -1,9 +1,28 @@
 #include <stdint.h>
 #include "drivers/uart_pl011.h"
 #include "arch/gicv3.h"
+#include "arch/irq.h"
 #include "arch/timer.h"
 
-extern "C" void irq_handler_el1(void) {
+namespace {
+
+__attribute__((noinline)) uint64_t touch_high_args(uint64_t a0, uint64_t a1,
+                                                   uint64_t a2, uint64_t a3,
+                                                   uint64_t a4, uint64_t a5,
+                                                   uint64_t a6, uint64_t a7) {
+  return (a4 ^ a5) + (a6 ^ a7) + (a0 | a1 | a2 | a3);
+}
+
+volatile uint64_t high_arg_sink;
+
+}  // namespace
+
+extern "C" void irq_handler_el1(struct irq_frame* frame) {
+  high_arg_sink = touch_high_args(frame->regs[0], frame->regs[1],
+                                  frame->regs[2], frame->regs[3],
+                                  frame->regs[4], frame->regs[5],
+                                  frame->regs[6], frame->regs[7]);
+
   uint32_t iar = gic_ack();
   uint32_t intid = iar & 0xFFFFFFu;
   if (intid == 27u) {           // virtual timer PPI


### PR DESCRIPTION
## Summary
- add an `irq_frame` description for the EL1 interrupt stack record
- extend `irq_el1` to spill/restore caller-saved registers plus SPSR/ELR
- pass the frame to `irq_handler_el1` and exercise a helper that uses x4–x7

## Testing
- make -j$(nproc) *(fails: clang is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8066236a883318883bfe8d8efc4fe