### PR TITLE
Enhance smoke test logging and validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,15 @@ jobs:
       - name: Build
         run: make -j
       - name: Smoke run (5s)
-        run: |
-          timeout 5s qemu-system-aarch64 -machine virt,gic-version=3 -cpu cortex-a72 \
-            -smp 1 -m 512 -nographic -serial mon:stdio \
-            -kernel build/kernel.elf || true
+        run: scripts/smoke_run.sh
       - name: Upload ELF
         uses: actions/upload-artifact@v4
         with:
           name: kernel-elf
           path: build/kernel.elf
+      - name: Upload QEMU smoke log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: qemu-smoke-log
+          path: build/qemu-smoke.log

--- a/README.md
+++ b/README.md
@@ -13,3 +13,10 @@ build outside the provided Docker devshell, install at least `clang`,
 `clang++`, `lld`, and `llvm-ar` before running `make -j$(nproc)`; otherwise the
 build will fail with `No such file or directory` errors when invoking the
 compiler.
+
+## Troubleshooting
+
+- The CI workflow uploads the serial console output from the smoke test as a
+  `qemu-smoke-log` artifact. If a run fails (or if you need to inspect the boot
+  sequence), download the artifact from the workflow summary to review the
+  captured `build/qemu-smoke.log` file.

--- a/scripts/smoke_run.sh
+++ b/scripts/smoke_run.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+BUILD_DIR="${REPO_ROOT}/build"
+LOG_PATH="${BUILD_DIR}/qemu-smoke.log"
+
+mkdir -p "${BUILD_DIR}"
+: >"${LOG_PATH}"
+
+CMD=(
+  qemu-system-aarch64
+  -machine virt,gic-version=3
+  -cpu cortex-a72
+  -smp 1
+  -m 512
+  -nographic
+  -serial mon:stdio
+  -kernel "${BUILD_DIR}/kernel.elf"
+)
+
+echo "[smoke] Launching QEMU with 5s timeout..."
+set +e
+# Capture output for log and console simultaneously.
+timeout 5s "${CMD[@]}" 2>&1 | tee "${LOG_PATH}"
+status=${PIPESTATUS[0]}
+set -e
+
+if [[ ${status} -eq 124 ]]; then
+  echo "[smoke] QEMU terminated after timeout (expected for idle kernel)."
+  status=0
+fi
+
+if [[ ${status} -ne 0 ]]; then
+  echo "[smoke] QEMU exited with status ${status}."
+  exit "${status}"
+fi
+
+required_messages=(
+  "[BOOT] UART ready"
+  "Timer IRQ armed @1kHz"
+)
+
+for message in "${required_messages[@]}"; do
+  if ! grep -qF "${message}" "${LOG_PATH}"; then
+    echo "::error ::Missing expected boot message: ${message}"
+    exit 1
+  fi
+done
+
+echo "[smoke] All expected boot messages found."


### PR DESCRIPTION
## Summary
- add a smoke test helper script that captures serial output, tolerates the expected timeout, and verifies key boot messages
- run the helper from CI and publish the captured QEMU smoke log artifact
- document the new artifact in the README troubleshooting guidance

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d83d2dae648331b05abee3285c42b5