### PR TITLE
Add timer-driven RR preemption

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ build/kmem.o: src/kmem.cc include/kmem.h
 
 build/thread.o: src/thread.cc include/thread.h include/arch/ctx.h include/arch/cpu_local.h include/kmem.h
 	mkdir -p build
-	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
+	$(CXX) $(CXXFLAGS) -mgeneral-regs-only -Iinclude -Isrc -c $< -o $@
 
 build/preempt.o: src/preempt.cc include/preempt.h include/arch/cpu_local.h include/thread.h
 	mkdir -p build

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,28 @@
-CXX     := clang++-20
-CC      := clang-20
-LD      := ld.lld-20
+CLANG_CANDIDATES   := clang-20 clang-19 clang-18 clang-17 clang-16 clang-15 clang-14 clang
+CXX_CANDIDATES     := clang++-20 clang++-19 clang++-18 clang++-17 clang++-16 clang++-15 clang++-14 clang++
+LLD_CANDIDATES     := ld.lld-20 ld.lld-19 ld.lld-18 ld.lld-17 ld.lld-16 ld.lld-15 ld.lld-14 ld.lld
+
+find_program = $(firstword $(foreach prog,$(1),$(if $(shell command -v $(prog) >/dev/null 2>&1 && echo 1),$(prog))))
+
+ifeq ($(origin CC), default)
+CC := $(call find_program,$(CLANG_CANDIDATES))
+endif
+ifeq ($(origin CXX), default)
+CXX := $(call find_program,$(CXX_CANDIDATES))
+endif
+ifeq ($(origin LD), default)
+LD := $(call find_program,$(LLD_CANDIDATES))
+endif
+
+ifeq ($(strip $(CC)),)
+$(error Could not find any of the following C compilers: $(CLANG_CANDIDATES))
+endif
+ifeq ($(strip $(CXX)),)
+$(error Could not find any of the following C++ compilers: $(CXX_CANDIDATES))
+endif
+ifeq ($(strip $(LD)),)
+$(error Could not find any of the following linkers: $(LLD_CANDIDATES))
+endif
 
 COMMON  := -target aarch64-unknown-none -ffreestanding -fno-stack-protector -O2 -g
 CXXFLAGS:= $(COMMON) -fno-exceptions -fno-rtti

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-CXX     := clang++
-CC      := clang
-LD      := ld.lld
+CXX     := clang++-20
+CC      := clang-20
+LD      := ld.lld-20
 
 COMMON  := -target aarch64-unknown-none -ffreestanding -fno-stack-protector -O2 -g
 CXXFLAGS:= $(COMMON) -fno-exceptions -fno-rtti
@@ -12,11 +12,14 @@ OBJS := \
   build/vectors.o \
   build/uart_pl011.o \
   build/gicv3.o \
+  build/ctx.o \
   build/cpu_local.o \
   build/barrier.o \
   build/timer.o \
   build/irq.o \
   build/kmem.o \
+  build/thread.o \
+  build/preempt.o \
   build/kmain.o
 
 ELF := build/kernel.elf
@@ -43,6 +46,10 @@ build/cpu_local.o: src/arch/aarch64/cpu_local.cc include/arch/cpu_local.h
 	mkdir -p build
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
 
+build/ctx.o: src/arch/aarch64/ctx.S include/arch/ctx.h
+	mkdir -p build
+	$(CC) $(ASFLAGS) -c $< -o $@
+
 build/timer.o: src/arch/aarch64/timer.cc include/arch/timer.h
 	mkdir -p build
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
@@ -52,6 +59,14 @@ build/irq.o: src/irq.cc include/irq.h
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
 
 build/kmem.o: src/kmem.cc include/kmem.h
+	mkdir -p build
+	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
+
+build/thread.o: src/thread.cc include/thread.h include/arch/ctx.h include/arch/cpu_local.h include/kmem.h
+	mkdir -p build
+	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
+
+build/preempt.o: src/preempt.cc include/preempt.h include/arch/cpu_local.h include/thread.h
 	mkdir -p build
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
 

--- a/include/arch/cpu_local.h
+++ b/include/arch/cpu_local.h
@@ -2,11 +2,16 @@
 #include <stddef.h>
 #include <stdint.h>
 
+struct Thread;
+
 struct alignas(64) cpu_local {
   uintptr_t irq_stack_top;   // points to __irq_stack_cpu0_top for CPU0
-  uintptr_t reserved[7];
-  // reserved: current_thread, preempt_cnt, cpu_id ...
-};
+  Thread*   current_thread;  // 目前執行緒
+  unsigned  preempt_cnt;     // preemption nesting counter
+  unsigned  need_resched;    // scheduler should pick another thread
+  unsigned long ticks;       // timer tick counter
+  unsigned  irq_depth;       // nesting depth of active IRQ handlers
+} __attribute__((aligned(64)));
 
 static_assert(offsetof(cpu_local, irq_stack_top) == 0, "irq_stack_top must be at offset 0");
 #ifdef __cplusplus

--- a/include/arch/cpu_local.h
+++ b/include/arch/cpu_local.h
@@ -12,8 +12,12 @@ struct alignas(64) cpu_local {
   unsigned long ticks;       // timer tick counter
   unsigned  irq_depth;       // nesting depth of active IRQ handlers
 } __attribute__((aligned(64)));
-
-static_assert(offsetof(cpu_local, irq_stack_top) == 0, "irq_stack_top must be at offset 0");
+#ifdef __cplusplus
+static_assert(offsetof(struct cpu_local, irq_stack_top) == 0,
+              "cpu_local.irq_stack_top at offset 0");
+static_assert(sizeof(struct cpu_local) % 64 == 0,
+              "cpu_local aligned to 64B");
+#endif
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/arch/ctx.h
+++ b/include/arch/ctx.h
@@ -1,0 +1,12 @@
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+// 交換執行緒堆疊指標：*prev_sp 存回舊 sp，切換到 next_sp
+void arch_switch(void** prev_sp, void* next_sp);
+// 首次切入新執行緒用的 thunk：讀取 cpu_local()->current_thread，
+// 呼叫其 entry(arg)，返回時呼叫 thread_exit() 結束。
+void thread_trampoline(void);
+#ifdef __cplusplus
+}
+#endif

--- a/include/preempt.h
+++ b/include/preempt.h
@@ -1,0 +1,10 @@
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+void preempt_disable(void);
+void preempt_enable(void);
+void preempt_return(void);
+#ifdef __cplusplus
+}
+#endif

--- a/include/thread.h
+++ b/include/thread.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <stddef.h>
+#include <stdint.h>
+
+struct Thread {
+  void*      sp;         // 保存的 stack pointer（arch_switch 用）
+  void     (*entry)(void*);
+  void*      arg;
+  Thread*    next;       // 單向循環佇列
+  int        id;
+  void*      stack_base; // for free/debug (暫不釋放)
+  size_t     stack_size;
+  int        budget;     // 剩餘時間片（tick 數）
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+void  sched_init(void);
+Thread* thread_create(void (*entry)(void*), void* arg, size_t stack_size);
+void  sched_add(Thread* t);
+void  sched_start(void);   // 切入第一個 thread（不可返回）
+void  thread_yield(void);  // cooperative 切換至下一個
+__attribute__((noreturn)) void thread_exit(void);
+void  sched_resched_from_irq_tail(void);
+void  sched_on_tick(void);
+#ifdef __cplusplus
+}
+#endif

--- a/scripts/smoke_run.sh
+++ b/scripts/smoke_run.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if ! command -v qemu-system-aarch64 >/dev/null 2>&1; then
+  echo "::error ::qemu-system-aarch64 not found in PATH; install QEMU to run smoke test"
+  exit 2
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 cd "${REPO_ROOT}"

--- a/scripts/smoke_run.sh
+++ b/scripts/smoke_run.sh
@@ -13,6 +13,12 @@ cd "${REPO_ROOT}"
 BUILD_DIR="${REPO_ROOT}/build"
 LOG_PATH="${BUILD_DIR}/qemu-smoke.log"
 
+echo "[smoke] Building kernel (make -j)..."
+if ! make -j; then
+  echo "::error ::Kernel build failed; see make output above"
+  exit 1
+fi
+
 mkdir -p "${BUILD_DIR}"
 : >"${LOG_PATH}"
 

--- a/src/arch/aarch64/cpu_local.cc
+++ b/src/arch/aarch64/cpu_local.cc
@@ -5,15 +5,16 @@ extern "C" struct cpu_local* cpu_local() {
   uintptr_t p=0; asm volatile("mrs %0, tpidr_el1":"=r"(p));
   return (struct cpu_local*)p;
 }
-extern "C" void cpu_local_boot_init() {
+extern "C" void cpu_local_boot_init(void) __attribute__((target("arch=armv8-a+nosimd")));
+extern "C" void cpu_local_boot_init(void) {
   static struct cpu_local cpu0;
   extern char __irq_stack_cpu0_top[];
   cpu0.irq_stack_top = (uintptr_t)__irq_stack_cpu0_top;
   cpu0.current_thread = nullptr;
-  cpu0.preempt_cnt = 0;
-  cpu0.need_resched = 0;
-  cpu0.ticks = 0;
-  cpu0.irq_depth = 0;
+  cpu0.preempt_cnt = 0u;
+  cpu0.need_resched = 0u;
+  cpu0.ticks = 0ul;
+  cpu0.irq_depth = 0u;
   uintptr_t p = (uintptr_t)&cpu0;
   asm volatile("msr tpidr_el1, %0" :: "r"(p));
   asm volatile("isb");

--- a/src/arch/aarch64/cpu_local.cc
+++ b/src/arch/aarch64/cpu_local.cc
@@ -9,6 +9,11 @@ extern "C" void cpu_local_boot_init() {
   static struct cpu_local cpu0;
   extern char __irq_stack_cpu0_top[];
   cpu0.irq_stack_top = (uintptr_t)__irq_stack_cpu0_top;
+  cpu0.current_thread = nullptr;
+  cpu0.preempt_cnt = 0;
+  cpu0.need_resched = 0;
+  cpu0.ticks = 0;
+  cpu0.irq_depth = 0;
   uintptr_t p = (uintptr_t)&cpu0;
   asm volatile("msr tpidr_el1, %0" :: "r"(p));
   asm volatile("isb");

--- a/src/arch/aarch64/ctx.S
+++ b/src/arch/aarch64/ctx.S
@@ -1,0 +1,38 @@
+    .text
+    .align  2
+    .global arch_switch
+    .type   arch_switch, %function
+arch_switch:
+    stp x19, x20, [sp, #-16]!
+    stp x21, x22, [sp, #-16]!
+    stp x23, x24, [sp, #-16]!
+    stp x25, x26, [sp, #-16]!
+    stp x27, x28, [sp, #-16]!
+    stp x29, x30, [sp, #-16]!
+    mov x2, sp
+    str x2, [x0]
+    mov sp, x1
+    ldp x29, x30, [sp], #16
+    ldp x27, x28, [sp], #16
+    ldp x25, x26, [sp], #16
+    ldp x23, x24, [sp], #16
+    ldp x21, x22, [sp], #16
+    ldp x19, x20, [sp], #16
+    ret
+    .size arch_switch, .-arch_switch
+
+    .align  2
+    .global thread_trampoline
+    .type   thread_trampoline, %function
+    .extern thread_exit
+thread_trampoline:
+    mrs x0, tpidr_el1
+    ldr x1, [x0, #8]      // cpu_local()->current_thread
+    ldr x2, [x1, #8]      // Thread::entry
+    ldr x3, [x1, #16]     // Thread::arg
+    mov x0, x3
+    blr x2
+    bl thread_exit
+1:  wfe
+    b 1b
+    .size thread_trampoline, .-thread_trampoline

--- a/src/irq.cc
+++ b/src/irq.cc
@@ -7,26 +7,7 @@
 #include "preempt.h"
 #include "thread.h"
 
-namespace {
-
-__attribute__((noinline)) uint64_t touch_high_args(uint64_t a0, uint64_t a1,
-                                                   uint64_t a2, uint64_t a3,
-                                                   uint64_t a4, uint64_t a5,
-                                                   uint64_t a6, uint64_t a7) {
-  return (a4 ^ a5) + (a6 ^ a7) + (a0 | a1 | a2 | a3);
-}
-
-volatile uint64_t high_arg_sink;
-
-}  // namespace
-
 extern "C" void irq_handler_el1(struct irq_frame* frame) {
-  static uint32_t irq_counter;
-  high_arg_sink = touch_high_args(frame->regs[0], frame->regs[1],
-                                  frame->regs[2], frame->regs[3],
-                                  frame->regs[4], frame->regs[5],
-                                  frame->regs[6], frame->regs[7]);
-
   auto* cpu = cpu_local();
   cpu->irq_depth++;
 
@@ -40,16 +21,8 @@ extern "C" void irq_handler_el1(struct irq_frame* frame) {
       frame->elr = reinterpret_cast<uint64_t>(&preempt_return);
     }
   } else {
-    uart_puts("IRQ?\n");
+    uart_puts("[irq] unexpected intid\n");
   }
   gic_eoi(iar);
   cpu->irq_depth--;
-
-  irq_counter++;
-  if ((irq_counter & 0xFFu) == 0u) {
-    struct cpu_local* local = cpu_local();
-    uintptr_t delta = (uintptr_t)local->irq_stack_top - frame->sp;
-    uart_puts("[irq] delta=");
-    uart_print_u64(delta);
-  }
 }

--- a/src/irq.cc
+++ b/src/irq.cc
@@ -4,6 +4,8 @@
 #include "arch/gicv3.h"
 #include "arch/irq.h"
 #include "arch/timer.h"
+#include "preempt.h"
+#include "thread.h"
 
 namespace {
 
@@ -25,14 +27,23 @@ extern "C" void irq_handler_el1(struct irq_frame* frame) {
                                   frame->regs[4], frame->regs[5],
                                   frame->regs[6], frame->regs[7]);
 
+  auto* cpu = cpu_local();
+  cpu->irq_depth++;
+
   uint32_t iar = gic_ack();
   uint32_t intid = iar & 0xFFFFFFu;
   if (intid == 27u) {           // virtual timer PPI
     timer_irq();
+    cpu->ticks++;
+    sched_on_tick();
+    if (cpu->current_thread && cpu->preempt_cnt == 0 && cpu->need_resched) {
+      frame->elr = reinterpret_cast<uint64_t>(&preempt_return);
+    }
   } else {
     uart_puts("IRQ?\n");
   }
   gic_eoi(iar);
+  cpu->irq_depth--;
 
   irq_counter++;
   if ((irq_counter & 0xFFu) == 0u) {

--- a/src/kmain.cc
+++ b/src/kmain.cc
@@ -46,7 +46,6 @@ extern "C" void kmain() {
   asm volatile("msr daifclr, #2"); // enable IRQ (clear I)
 
   uart_puts("[diag] IRQ enabled\n");
-  uart_puts("Timer IRQ armed @1kHz\n");
   uart_puts("[sched] starting (coop)\n");
   sched_start(); // 不返回
   while (1) { asm volatile("wfe"); }

--- a/src/kmain.cc
+++ b/src/kmain.cc
@@ -1,9 +1,15 @@
 #include <stdint.h>
 #include "drivers/uart_pl011.h"
+#include "arch/cpu_local.h"
 #include "arch/gicv3.h"
 #include "arch/timer.h"
-#include "arch/cpu_local.h"
+#include "arch/ctx.h"
 #include "kmem.h"
+#include "thread.h"
+#include "preempt.h"
+
+void a(void*);
+void b(void*);
 
 extern "C" void kmain() {
   uart_init();
@@ -13,11 +19,49 @@ extern "C" void kmain() {
 
   kmem_init();
 
+  sched_init();
+  Thread* ta = thread_create(a, reinterpret_cast<void*>(0xA), 16 * 1024);
+  Thread* tb = thread_create(b, reinterpret_cast<void*>(0xB), 16 * 1024);
+  if (!ta || !tb) {
+    uart_puts("[sched] thread_create failed\n");
+    while (1) { asm volatile("wfe"); }
+  }
+  sched_add(ta);
+  sched_add(tb);
+
   gic_init();
   timer_init_hz(1000); // 1 kHz
 
   asm volatile("msr daifclr, #2"); // enable IRQ (clear I)
 
   uart_puts("Timer IRQ armed @1kHz\n");
+  uart_puts("[sched] starting (coop)\n");
+  sched_start(); // 不返回
   while (1) { asm volatile("wfe"); }
+}
+
+static inline void spin(unsigned n) {
+  for (volatile unsigned i = 0; i < n; i++) {
+  }
+}
+
+void a(void* arg) {
+  (void)arg;
+  uart_puts("A");
+  while (1) {
+    preempt_disable();
+    uart_puts("a");
+    spin(50000);
+    preempt_enable();
+    spin(100000);
+  }
+}
+
+void b(void* arg) {
+  (void)arg;
+  uart_puts("B");
+  while (1) {
+    uart_puts("b");
+    spin(120000);
+  }
 }

--- a/src/kmain.cc
+++ b/src/kmain.cc
@@ -15,25 +15,37 @@ extern "C" void kmain() {
   uart_init();
   uart_puts("[BOOT] UART ready\n");
 
+  uart_puts("[diag] cpu_local_boot_init begin\n");
   cpu_local_boot_init();
+  uart_puts("[diag] cpu_local_boot_init end\n");
 
+  uart_puts("[diag] kmem_init begin\n");
   kmem_init();
+  uart_puts("[diag] kmem_init end\n");
 
+  uart_puts("[diag] sched_init\n");
   sched_init();
+  uart_puts("[diag] thread_create a\n");
   Thread* ta = thread_create(a, reinterpret_cast<void*>(0xA), 16 * 1024);
+  uart_puts("[diag] thread_create b\n");
   Thread* tb = thread_create(b, reinterpret_cast<void*>(0xB), 16 * 1024);
   if (!ta || !tb) {
     uart_puts("[sched] thread_create failed\n");
     while (1) { asm volatile("wfe"); }
   }
+  uart_puts("[diag] sched_add a\n");
   sched_add(ta);
+  uart_puts("[diag] sched_add b\n");
   sched_add(tb);
 
+  uart_puts("[diag] gic_init\n");
   gic_init();
+  uart_puts("[diag] timer_init_hz\n");
   timer_init_hz(1000); // 1 kHz
 
   asm volatile("msr daifclr, #2"); // enable IRQ (clear I)
 
+  uart_puts("[diag] IRQ enabled\n");
   uart_puts("Timer IRQ armed @1kHz\n");
   uart_puts("[sched] starting (coop)\n");
   sched_start(); // 不返回

--- a/src/preempt.cc
+++ b/src/preempt.cc
@@ -1,0 +1,29 @@
+#include "preempt.h"
+
+#include "arch/cpu_local.h"
+#include "thread.h"
+
+extern "C" void preempt_disable(void) {
+  auto* cpu = cpu_local();
+  cpu->preempt_cnt++;
+  __asm__ __volatile__("" ::: "memory");
+}
+
+extern "C" void preempt_enable(void) {
+  auto* cpu = cpu_local();
+  __asm__ __volatile__("" ::: "memory");
+  if (cpu->preempt_cnt == 0) {
+    return;
+  }
+  cpu->preempt_cnt--;
+  if (cpu->preempt_cnt == 0 && cpu->need_resched && cpu->irq_depth == 0) {
+    sched_resched_from_irq_tail();
+  }
+}
+
+extern "C" void preempt_return(void) {
+  auto* cpu = cpu_local();
+  if (cpu->preempt_cnt == 0 && cpu->need_resched) {
+    sched_resched_from_irq_tail();
+  }
+}

--- a/src/thread.cc
+++ b/src/thread.cc
@@ -36,11 +36,13 @@ extern "C" Thread* thread_create(void (*entry)(void*), void* arg, size_t stack_s
   Thread* t = reinterpret_cast<Thread*>(
       kmem_alloc_aligned(sizeof(Thread), alignof(Thread)));
   if (!t) {
+    uart_puts("[sched][err] no memory for Thread struct\n");
     return nullptr;
   }
 
   void* stack = kmem_alloc_aligned(stack_size, 16);
   if (!stack) {
+    uart_puts("[sched][err] no memory for thread stack\n");
     return nullptr;
   }
 
@@ -68,6 +70,14 @@ extern "C" Thread* thread_create(void (*entry)(void*), void* arg, size_t stack_s
   t->stack_base = stack;
   t->stack_size = stack_size;
   t->budget = RR_QUANTUM_TICKS;
+
+  uart_puts("[sched][diag] thread created id=");
+  uart_print_u64(static_cast<unsigned long long>(t->id));
+  uart_puts(" sp=");
+  uart_print_u64(static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(t->sp)));
+  uart_puts(" stack=");
+  uart_print_u64(static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(t->stack_base)));
+  uart_puts("\n");
   return t;
 }
 

--- a/src/thread.cc
+++ b/src/thread.cc
@@ -1,0 +1,157 @@
+#include "thread.h"
+
+#include "arch/ctx.h"
+#include "arch/cpu_local.h"
+#include "drivers/uart_pl011.h"
+#include "kmem.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define RR_QUANTUM_TICKS 5
+
+namespace {
+Thread* rq_head = nullptr;
+Thread* rq_tail = nullptr;
+int next_thread_id = 1;
+
+static void do_switch(Thread* cur, Thread* next) {
+  auto* cpu = cpu_local();
+  cpu->current_thread = next;
+  arch_switch(&cur->sp, next->sp);
+}
+}
+
+extern "C" void sched_init(void) {
+  rq_head = nullptr;
+  rq_tail = nullptr;
+  next_thread_id = 1;
+}
+
+extern "C" Thread* thread_create(void (*entry)(void*), void* arg, size_t stack_size) {
+  if (entry == nullptr || stack_size == 0) {
+    return nullptr;
+  }
+
+  Thread* t = reinterpret_cast<Thread*>(
+      kmem_alloc_aligned(sizeof(Thread), alignof(Thread)));
+  if (!t) {
+    return nullptr;
+  }
+
+  void* stack = kmem_alloc_aligned(stack_size, 16);
+  if (!stack) {
+    return nullptr;
+  }
+
+  uintptr_t stack_top = reinterpret_cast<uintptr_t>(stack) + stack_size;
+  stack_top &= ~static_cast<uintptr_t>(0xF);
+  uintptr_t* sp_words = reinterpret_cast<uintptr_t*>(stack_top);
+  auto push_pair = [&sp_words](uintptr_t first, uintptr_t second) {
+    sp_words -= 2;
+    sp_words[0] = first;
+    sp_words[1] = second;
+  };
+
+  push_pair(0, 0);  // (x19, x20)
+  push_pair(0, 0);  // (x21, x22)
+  push_pair(0, 0);  // (x23, x24)
+  push_pair(0, 0);  // (x25, x26)
+  push_pair(0, 0);  // (x27, x28)
+  push_pair(0, reinterpret_cast<uintptr_t>(&thread_trampoline)); // (x29, LR)
+
+  t->sp = sp_words;
+  t->entry = entry;
+  t->arg = arg;
+  t->next = nullptr;
+  t->id = next_thread_id++;
+  t->stack_base = stack;
+  t->stack_size = stack_size;
+  t->budget = RR_QUANTUM_TICKS;
+  return t;
+}
+
+extern "C" void sched_add(Thread* t) {
+  if (!t) {
+    return;
+  }
+  if (!rq_head) {
+    rq_head = t;
+    rq_tail = t;
+    t->next = t;
+    return;
+  }
+  t->next = rq_head;
+  rq_tail->next = t;
+  rq_tail = t;
+}
+
+extern "C" void sched_start(void) {
+  Thread* cur = rq_head;
+  if (!cur) {
+    uart_puts("[sched] no threads\n");
+    while (1) {
+      asm volatile("wfe");
+    }
+  }
+  cur->budget = RR_QUANTUM_TICKS;
+  cpu_local()->current_thread = cur;
+  void* boot_sp = nullptr;
+  arch_switch(&boot_sp, cur->sp);
+  while (1) {
+    asm volatile("wfe");
+  }
+}
+
+extern "C" void thread_yield(void) {
+  auto* cpu = cpu_local();
+  Thread* cur = cpu->current_thread;
+  Thread* next = (cur && cur->next) ? cur->next : cur;
+  if (next && next != cur) {
+    do_switch(cur, next);
+  }
+}
+
+extern "C" __attribute__((noreturn)) void thread_exit(void) {
+  uart_puts("[thread] exit\n");
+  while (1) {
+    asm volatile("wfe");
+  }
+}
+
+extern "C" void sched_on_tick(void) {
+  auto* cpu = cpu_local();
+  Thread* cur = cpu->current_thread;
+  if (!cur) {
+    return;
+  }
+  if (cpu->preempt_cnt) {
+    return;
+  }
+  if (cur->budget > 0) {
+    cur->budget--;
+  }
+  if (cur->budget <= 0) {
+    cpu->need_resched = 1;
+    cur->budget = RR_QUANTUM_TICKS;
+  }
+}
+
+extern "C" void sched_resched_from_irq_tail(void) {
+  auto* cpu = cpu_local();
+  Thread* cur = cpu->current_thread;
+  if (!cur) {
+    cpu->need_resched = 0;
+    return;
+  }
+  if (cpu->preempt_cnt) {
+    return;
+  }
+  Thread* next = cur->next ? cur->next : cur;
+  if (next == cur) {
+    cpu->need_resched = 0;
+    return;
+  }
+  do_switch(cur, next);
+  cpu->need_resched = 0;
+}

--- a/src/thread.cc
+++ b/src/thread.cc
@@ -28,15 +28,6 @@ extern "C" void sched_init(void) {
   next_thread_id = 1;
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
-#define THREAD_GENERAL_REGS_ONLY __attribute__((target("general-regs-only")))
-#else
-#define THREAD_GENERAL_REGS_ONLY
-#endif
-
-extern "C" Thread* thread_create(void (*entry)(void*), void* arg, size_t stack_size)
-    THREAD_GENERAL_REGS_ONLY;
-
 extern "C" Thread* thread_create(void (*entry)(void*), void* arg, size_t stack_size) {
   uart_puts("[diag] thread_create enter\n");
   if (entry == nullptr || stack_size == 0) {
@@ -188,4 +179,3 @@ extern "C" void sched_resched_from_irq_tail(void) {
   cpu->need_resched = 0;
 }
 
-#undef THREAD_GENERAL_REGS_ONLY


### PR DESCRIPTION
## Summary
- add preempt API and CPU-local accounting for timer-driven rescheduling
- hook timer IRQ to round-robin scheduler and provide RR budget handling
- expand smoke test expectations for preemption demo output

## Testing
- `make -j`
- `scripts/smoke_run.sh` *(fails: qemu-system-aarch64 not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_690cc15f395c8331aeefd0b6107a5664