### PR TITLE
Feat/rpi4: bring-up scaffolding + platform abstraction (no QEMU virt regressions)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ START_SRC ?= boot/start.S
 LDSCRIPT ?= boot/kernel.ld
 
 COMMON  := -target aarch64-unknown-none -ffreestanding -fno-stack-protector -O2 -g
-# 暫時關閉自動向量化（等 FPSIMD context 完整驗證後可移除）
+# Temporarily disable auto-vectorization (remove once FPSIMD context is fully validated).
 CXXFLAGS:= $(COMMON) -std=c++17 -fno-exceptions -fno-rtti -Wall -Wextra -DARM_TIMER_DIAG=1 -DUSE_CNTP=0 -fno-vectorize -fno-slp-vectorize
 ASFLAGS := -target aarch64-unknown-none -ffreestanding
 LDFLAGS := -nostdlib -static -T $(LDSCRIPT)

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ LDSCRIPT ?= boot/kernel.ld
 
 COMMON  := -target aarch64-unknown-none -ffreestanding -fno-stack-protector -O2 -g
 # 暫時關閉自動向量化（等 FPSIMD context 完整驗證後可移除）
-CXXFLAGS:= $(COMMON) -fno-exceptions -fno-rtti -Wall -Wextra -DARM_TIMER_DIAG=1 -DUSE_CNTP=0 -fno-vectorize -fno-slp-vectorize
+CXXFLAGS:= $(COMMON) -std=c++17 -fno-exceptions -fno-rtti -Wall -Wextra -DARM_TIMER_DIAG=1 -DUSE_CNTP=0 -fno-vectorize -fno-slp-vectorize
 ASFLAGS := -target aarch64-unknown-none -ffreestanding
 LDFLAGS := -nostdlib -static -T $(LDSCRIPT)
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CLANG_CANDIDATES   := clang-20 clang-19 clang-18 clang-17 clang-16 clang-15 clang-14 clang
 CXX_CANDIDATES     := clang++-20 clang++-19 clang++-18 clang++-17 clang++-16 clang++-15 clang++-14 clang++
 LLD_CANDIDATES     := ld.lld-20 ld.lld-19 ld.lld-18 ld.lld-17 ld.lld-16 ld.lld-15 ld.lld-14 ld.lld
+OBJCOPY_CANDIDATES := llvm-objcopy objcopy
 
 find_program = $(firstword $(foreach prog,$(1),$(if $(shell command -v $(prog) >/dev/null 2>&1 && echo 1),$(prog))))
 
@@ -13,6 +14,9 @@ endif
 ifeq ($(origin LD), default)
 LD := $(call find_program,$(LLD_CANDIDATES))
 endif
+ifeq ($(origin OBJCOPY), default)
+OBJCOPY := $(call find_program,$(OBJCOPY_CANDIDATES))
+endif
 
 ifeq ($(strip $(CC)),)
 $(error Could not find any of the following C compilers: $(CLANG_CANDIDATES))
@@ -24,15 +28,42 @@ ifeq ($(strip $(LD)),)
 $(error Could not find any of the following linkers: $(LLD_CANDIDATES))
 endif
 
+OBJ_DIR ?= build
+START_SRC ?= boot/start.S
+LDSCRIPT ?= boot/kernel.ld
+
 COMMON  := -target aarch64-unknown-none -ffreestanding -fno-stack-protector -O2 -g
 # 暫時關閉自動向量化（等 FPSIMD context 完整驗證後可移除）
 CXXFLAGS:= $(COMMON) -fno-exceptions -fno-rtti -Wall -Wextra -DARM_TIMER_DIAG=1 -DUSE_CNTP=0 -fno-vectorize -fno-slp-vectorize
 ASFLAGS := -target aarch64-unknown-none -ffreestanding
-LDFLAGS := -nostdlib -static -T boot/kernel.ld
+LDFLAGS := -nostdlib -static -T $(LDSCRIPT)
 
 # DMA window mapping policy (default: CACHEABLE so coherency bugs surface).
 DMA_WINDOW_POLICY ?= CACHEABLE
 DMA_LAB_MODE ?= 0
+
+# Platform selection.
+# - virt: QEMU -machine virt (default, used by CI smoke test)
+# - rpi4: Raspberry Pi 4 (AArch64 firmware-loaded kernel8.img)
+PLATFORM ?= virt
+
+ifeq ($(PLATFORM),virt)
+CXXFLAGS += -DPLATFORM_VIRT=1
+PLATFORM_SRC := src/platform/virt.cc
+MMU_SRC := src/arch/aarch64/mmu.cc
+else ifeq ($(PLATFORM),rpi4)
+CXXFLAGS += -DPLATFORM_RPI4=1
+PLATFORM_SRC := src/platform/rpi4.cc
+MMU_SRC := src/arch/aarch64/mmu_rpi4.cc
+else
+$(error PLATFORM must be virt or rpi4)
+endif
+
+ifeq ($(PLATFORM),rpi4)
+ifneq ($(strip $(RPI4_UART_CLOCK_HZ)),)
+CXXFLAGS += -DRPI4_UART_CLOCK_HZ=$(RPI4_UART_CLOCK_HZ)
+endif
+endif
 
 ifeq ($(DMA_WINDOW_POLICY),CACHEABLE)
 CXXFLAGS += -DDMA_WINDOW_POLICY_CACHEABLE=1
@@ -45,103 +76,108 @@ endif
 CXXFLAGS += -DDMA_LAB_MODE=$(DMA_LAB_MODE)
 
 OBJS := \
-  build/start.o \
-  build/vectors.o \
-  build/uart_pl011.o \
-  build/gicv3.o \
-  build/ctx.o \
-  build/cpu_local.o \
-  build/barrier.o \
-  build/mmu.o \
-  build/timer.o \
-  build/irq.o \
-  build/kmem.o \
-  build/thread.o \
-  build/preempt.o \
-  build/dma.o \
-  build/dma_lab.o \
-  build/except.o \
-  build/fpsimd.o \
-  build/kmain.o
+  $(OBJ_DIR)/start.o \
+  $(OBJ_DIR)/vectors.o \
+  $(OBJ_DIR)/uart_pl011.o \
+  $(OBJ_DIR)/platform.o \
+  $(OBJ_DIR)/gicv3.o \
+  $(OBJ_DIR)/ctx.o \
+  $(OBJ_DIR)/cpu_local.o \
+  $(OBJ_DIR)/barrier.o \
+  $(OBJ_DIR)/mmu.o \
+  $(OBJ_DIR)/timer.o \
+  $(OBJ_DIR)/irq.o \
+  $(OBJ_DIR)/kmem.o \
+  $(OBJ_DIR)/thread.o \
+  $(OBJ_DIR)/preempt.o \
+  $(OBJ_DIR)/dma.o \
+  $(OBJ_DIR)/dma_lab.o \
+  $(OBJ_DIR)/except.o \
+  $(OBJ_DIR)/fpsimd.o \
+  $(OBJ_DIR)/kmain.o
 
-ELF := build/kernel.elf
+ELF ?= $(OBJ_DIR)/kernel.elf
 
 all: $(ELF)
 
-build/start.o: boot/start.S
-	mkdir -p build
+$(OBJ_DIR)/start.o: $(START_SRC)
+	mkdir -p $(OBJ_DIR)
 	$(CC) $(ASFLAGS) -c $< -o $@
 
-build/vectors.o: boot/vectors.S
-	mkdir -p build
+$(OBJ_DIR)/vectors.o: boot/vectors.S
+	mkdir -p $(OBJ_DIR)
 	$(CC) $(ASFLAGS) -c $< -o $@
 
-build/uart_pl011.o: src/drivers/uart_pl011.cc src/drivers/uart_pl011.h
-	mkdir -p build
+$(OBJ_DIR)/uart_pl011.o: src/drivers/uart_pl011.cc src/drivers/uart_pl011.h
+	mkdir -p $(OBJ_DIR)
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
 
-build/gicv3.o: src/arch/aarch64/gicv3.cc include/arch/gicv3.h
-	mkdir -p build
+$(OBJ_DIR)/platform.o: $(PLATFORM_SRC) include/platform.h src/drivers/uart_pl011.h
+	mkdir -p $(OBJ_DIR)
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
 
-build/cpu_local.o: src/arch/aarch64/cpu_local.cc include/arch/cpu_local.h
-	mkdir -p build
+$(OBJ_DIR)/gicv3.o: src/arch/aarch64/gicv3.cc include/arch/gicv3.h
+	mkdir -p $(OBJ_DIR)
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
 
-build/ctx.o: src/arch/aarch64/ctx.S include/arch/ctx.h
-	mkdir -p build
+$(OBJ_DIR)/cpu_local.o: src/arch/aarch64/cpu_local.cc include/arch/cpu_local.h
+	mkdir -p $(OBJ_DIR)
+	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
+
+$(OBJ_DIR)/ctx.o: src/arch/aarch64/ctx.S include/arch/ctx.h
+	mkdir -p $(OBJ_DIR)
 	$(CC) $(ASFLAGS) -c $< -o $@
 
-build/timer.o: src/arch/aarch64/timer.cc include/arch/timer.h
-	mkdir -p build
+$(OBJ_DIR)/timer.o: src/arch/aarch64/timer.cc include/arch/timer.h
+	mkdir -p $(OBJ_DIR)
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
 
-build/irq.o: src/irq.cc include/irq.h
-	mkdir -p build
+$(OBJ_DIR)/irq.o: src/irq.cc include/irq.h
+	mkdir -p $(OBJ_DIR)
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
 
-build/kmem.o: src/kmem.cc include/kmem.h
-	mkdir -p build
+$(OBJ_DIR)/kmem.o: src/kmem.cc include/kmem.h
+	mkdir -p $(OBJ_DIR)
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
 
-build/thread.o: src/thread.cc include/thread.h include/arch/ctx.h include/arch/cpu_local.h include/kmem.h
-	mkdir -p build
+$(OBJ_DIR)/thread.o: src/thread.cc include/thread.h include/arch/ctx.h include/arch/cpu_local.h include/kmem.h
+	mkdir -p $(OBJ_DIR)
 	$(CXX) $(CXXFLAGS) -mgeneral-regs-only -Iinclude -Isrc -c $< -o $@
 
-build/preempt.o: src/preempt.cc include/preempt.h include/arch/cpu_local.h include/thread.h
-	mkdir -p build
+$(OBJ_DIR)/preempt.o: src/preempt.cc include/preempt.h include/arch/cpu_local.h include/thread.h
+	mkdir -p $(OBJ_DIR)
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
 
-build/dma.o: src/dma.cc include/dma.h include/arch/barrier.h
-	mkdir -p build
+$(OBJ_DIR)/dma.o: src/dma.cc include/dma.h include/arch/barrier.h
+	mkdir -p $(OBJ_DIR)
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
 
-build/dma_lab.o: src/dma_lab.cc include/dma_lab.h include/dma.h include/kmem.h include/arch/barrier.h
-	mkdir -p build
+$(OBJ_DIR)/dma_lab.o: src/dma_lab.cc include/dma_lab.h include/dma.h include/kmem.h include/arch/barrier.h
+	mkdir -p $(OBJ_DIR)
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
 
-build/except.o: src/arch/aarch64/except.cc include/arch/except.h
-	mkdir -p build
+$(OBJ_DIR)/except.o: src/arch/aarch64/except.cc include/arch/except.h
+	mkdir -p $(OBJ_DIR)
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
 
 # NEW: FPSIMD
-build/fpsimd.o: src/arch/aarch64/fpsimd.cc include/arch/fpsimd.h include/arch/cpu_local.h include/thread.h
-	mkdir -p build
+$(OBJ_DIR)/fpsimd.o: src/arch/aarch64/fpsimd.cc include/arch/fpsimd.h include/arch/cpu_local.h include/thread.h
+	mkdir -p $(OBJ_DIR)
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
 
-build/kmain.o: src/kmain.cc
-	mkdir -p build
+$(OBJ_DIR)/kmain.o: src/kmain.cc
+	mkdir -p $(OBJ_DIR)
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
 
-build/barrier.o: src/arch/aarch64/barrier.cc include/arch/barrier.h
-	mkdir -p build
+$(OBJ_DIR)/barrier.o: src/arch/aarch64/barrier.cc include/arch/barrier.h
+	mkdir -p $(OBJ_DIR)
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
 
-build/mmu.o: src/arch/aarch64/mmu.cc include/arch/mmu.h
-	mkdir -p build
+$(OBJ_DIR)/mmu.o: $(MMU_SRC) include/arch/mmu.h
+	mkdir -p $(OBJ_DIR)
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
 
-$(ELF): $(OBJS) boot/kernel.ld
+$(ELF): $(OBJS) $(LDSCRIPT)
 	$(LD) $(LDFLAGS) $(OBJS) -o $(ELF)
 
 run: $(ELF)
@@ -157,4 +193,13 @@ run: $(ELF)
 clean:
 	rm -rf build .qemu.log
 
-.PHONY: all run clean
+.PHONY: all run clean rpi4
+
+RPI4_ELF := build/kernel_rpi4.elf
+RPI4_IMG := build/kernel8.img
+
+rpi4:
+	$(MAKE) PLATFORM=rpi4 OBJ_DIR=build/rpi4 START_SRC=boot/rpi4_start.S LDSCRIPT=boot/kernel_rpi4.ld ELF=$(RPI4_ELF) all
+	@if [ -z "$(OBJCOPY)" ]; then echo "Could not find objcopy tool (tried: $(OBJCOPY_CANDIDATES))"; exit 2; fi
+	$(OBJCOPY) -O binary $(RPI4_ELF) $(RPI4_IMG)
+	@echo "[rpi4] Wrote $(RPI4_IMG) (ELF: $(RPI4_ELF))"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 ./scripts/devshell.sh
 make run
 
+## Raspberry Pi 4 (bring-up)
+
+- Build image: `make rpi4`
+- Outputs: `build/kernel8.img` (firmware) and `build/kernel_rpi4.elf` (debug)
+- Instructions: `docs/rpi4.md`
+
 ## Memory layout
 The linker script at `boot/kernel.ld` exposes a handful of global symbols that
 describe the static memory map:

--- a/README.md
+++ b/README.md
@@ -1,16 +1,35 @@
 # Micro-kernel-using-C- (AArch64 on QEMU)
-- Build toolchain via Docker (LLVM + LLD + QEMU)
-- Minimal bare-metal AArch64 kernel (QEMU -machine virt)
+- Minimal bare-metal AArch64 kernel targeting QEMU `-machine virt`
+- Toolchain via Docker (LLVM + LLD + QEMU)
+- MMU + I/D caches enabled early (to surface DMA coherency issues)
 
-## Quick Start
+## Quick start (QEMU virt)
+
+```sh
 ./scripts/devshell.sh
 make run
+```
+
+Run the CI-equivalent smoke test locally:
+
+```sh
+./scripts/smoke_run.sh
+```
 
 ## Raspberry Pi 4 (bring-up)
 
 - Build image: `make rpi4`
 - Outputs: `build/kernel8.img` (firmware) and `build/kernel_rpi4.elf` (debug)
 - Instructions: `docs/rpi4.md`
+
+## Build knobs
+
+All knobs are Make variables:
+
+- `PLATFORM=virt|rpi4` (default: `virt`)
+- `DMA_WINDOW_POLICY=CACHEABLE|NONCACHEABLE` (default: `CACHEABLE`)
+- `DMA_LAB_MODE=0|1|2|...` (default: `0`)
+- `RPI4_UART_CLOCK_HZ=<hz>` (only used when building `PLATFORM=rpi4`)
 
 ## Memory layout
 The linker script at `boot/kernel.ld` exposes a handful of global symbols that
@@ -73,6 +92,90 @@ Examples:
 - Run the full suite: `DMA_LAB_MODE=1 DMA_WINDOW_POLICY=CACHEABLE scripts/dma_lab_run.sh`
 - Run a single case (best-effort): `DMA_LAB_MODE=3 DMA_WINDOW_POLICY=CACHEABLE scripts/dma_lab_run.sh`
 
+## Design case studies (STAR)
+
+This project intentionally enables caches early and treats DMA as non-coherent,
+because most real firmware/driver bugs only show up once the CPU is caching.
+
+### 1) Enable MMU + caches without breaking MMIO
+
+- Situation: the kernel needs caches enabled to expose real DMA coherency bugs,
+  but UART/GIC/timer are MMIO and must not be cached.
+- Task: turn on `SCTLR_EL1.M/C/I` while keeping MMIO strongly ordered and keeping
+  the existing IRQ/scheduler flow stable.
+- Action:
+  - Build a minimal 4 KiB-granule identity map (`src/arch/aarch64/mmu.cc` for
+    QEMU virt; `src/arch/aarch64/mmu_rpi4.cc` for RPi4).
+  - Map MMIO windows as `Device-nGnRE` and kernel/RAM as `Normal WBWA`, plus a
+    `Normal non-cacheable` alias for lab/device-view experiments.
+  - Program `MAIR_EL1/TCR_EL1/TTBR0_EL1` and enable `SCTLR_EL1` while preserving
+    architectural RES1 bits (no hard-coded constants).
+- Result:
+  - Boot logs include `[mmu] enabled ... (C=1, I=1, M=1)` and the system keeps
+    printing via UART with interrupts and scheduling still working on QEMU.
+
+### 2) Linux-style DMA sync semantics (non-coherent model)
+
+- Situation: the DMA engine is a software memcpy, but we intentionally model it
+  as a non-coherent device so cache bugs are reproducible on QEMU.
+- Task: make the DMA self-test pass reliably with caches enabled without
+  forcing all buffers to be non-cacheable.
+- Action:
+  - Implement explicit coherency primitives in `src/dma.cc`:
+    - `dma_prepare_to_device(buf,len)`: clean to PoC + `dma_wmb()` (`dmb oshst`)
+    - `dma_complete_from_device(buf,len)`: `dma_rmb()` (`dmb oshld`) + invalidate
+  - Ensure descriptor writes are cleaned and ordered before publishing to the
+    “device”.
+  - Guard cache maintenance so we do not issue DC operations on non-cacheable or
+    Device mappings.
+- Result:
+  - The default QEMU virt path prints `[DMA OK]` under `SCTLR_EL1.C=1`.
+
+### 3) Deterministic DMA coherency lab (fail → fix evidence)
+
+- Situation: DMA coherency issues can be timing-sensitive and hard to reproduce.
+- Task: build a lab-grade harness that can demonstrate a bug, apply the correct
+  fix, and produce evidence — all in a single run.
+- Action:
+  - Provide a non-cacheable alias mapping and strict VA conversion helpers
+    (`include/dma.h`).
+  - Add `DMA_LAB_MODE` test cases (`src/dma_lab.cc`) that exercise common
+    non-coherent failure modes (stale reads, publish ordering, completion flag
+    races, cache-line sharing hazards) and then apply the corresponding fixes.
+- Result:
+  - `scripts/dma_lab_run.sh` can reproduce and validate coherency fixes without
+    needing real DMA hardware.
+
+### 4) CI smoke tests that fail on “silent badness”
+
+- Situation: regressions (e.g. caches accidentally off, wrong barriers, or QEMU
+  unimplemented behavior) can be masked by unrelated log output.
+- Task: ensure CI fails fast on silent correctness regressions.
+- Action (`scripts/smoke_run.sh`):
+  - Assert `[mmu] enabled ... (C=1, I=1, M=1)` is present.
+  - Compile `dma_*` barriers to assembly and grep for `dmb osh*` to lock in
+    semantics.
+  - Parse QEMU trace output for `guest_errors/unimp` and fail immediately.
+- Result:
+  - CI catches common “looks fine but is wrong” failures early and deterministically.
+
+### 5) Platform abstraction for real boards (RPi4 bring-up scaffold)
+
+- Situation: QEMU virt is a great testbed, but real boards differ in boot flow,
+  UART base/clock/GPIO muxing, and interrupt controller details.
+- Task: add an extendable platform layer without breaking the existing QEMU virt
+  build/run/CI pipeline.
+- Action:
+  - Add `platform_early_init()` and platform selection (`PLATFORM=...`) to keep
+    board-specific constants out of core code (`include/platform.h`,
+    `src/platform/*`).
+  - Add an RPi4 boot stub (`boot/rpi4_start.S`) with EL2→EL1 transition markers,
+    plus an RPi4 linker script (`boot/kernel_rpi4.ld`) and `make rpi4` image
+    output (`kernel8.img`).
+- Result:
+  - You can build a firmware-loadable `kernel8.img` while keeping QEMU virt CI
+    unchanged.
+
 ## Host build prerequisites
 
 The `Makefile` expects the LLVM toolchain to be available on the host. If you
@@ -87,3 +190,6 @@ compiler.
   `qemu-smoke-log` artifact. If a run fails (or if you need to inspect the boot
   sequence), download the artifact from the workflow summary to review the
   captured `build/qemu-smoke.log` file.
+- If `scripts/smoke_run.sh` fails with `guest_errors/unimp`, check
+  `build/qemu-trace.log` first; this usually indicates QEMU is warning about an
+  unimplemented CPU/system feature the kernel touched.

--- a/boot/kernel_rpi4.ld
+++ b/boot/kernel_rpi4.ld
@@ -1,0 +1,36 @@
+ENTRY(_start)
+SECTIONS {
+  /* Raspberry Pi firmware loads a 64-bit kernel image (kernel8.img) at 0x80000. */
+  . = 0x80000;
+  .text : { *(.text.boot) *(.text*) }
+  .rodata : { *(.rodata*) }
+  .data : { *(.data*) }
+  . = ALIGN(8);
+  .bss : {
+    __bss_start = .;
+    *(.bss*) *(COMMON)
+    . = ALIGN(8);
+    __bss_end = .;
+  }
+
+  . = ALIGN(16);
+  . += 0x4000;      /* 16KB boot stack */
+  __boot_stack_top = .;
+
+  . = ALIGN(64);
+  __irq_stack_cpu0 = .;
+  . += 0x4000;      /* 16KB per-CPU IRQ stack for CPU0 */
+  __irq_stack_cpu0_end = .;
+  __irq_stack_cpu0_top = __irq_stack_cpu0_end;
+
+  . = ALIGN(4096);
+  _heap_start = .;
+  . += 0x100000;    /* 1MB kernel heap */
+  _heap_end = .;
+
+  . = ALIGN(4096);
+  __dma_nc_start = .;
+  . += 0x20000;     /* 128KB DMA window (policy-configurable) */
+  __dma_nc_end = .;
+}
+

--- a/boot/rpi4_start.S
+++ b/boot/rpi4_start.S
@@ -1,0 +1,106 @@
+  .section .text.boot, "ax"
+  .global _start
+  .extern kmain
+  .extern __vec_base
+  .extern __bss_start
+  .extern __bss_end
+
+  // Raspberry Pi 4 (BCM2711) PL011 UART0 base (CPU physical address).
+  .equ RPI4_UART0_BASE, 0xFE201000
+
+// Best-effort early UART putc. Requires firmware/GPIO to route UART0 to pins.
+pl011_putc_early:
+ ldr x1, =RPI4_UART0_BASE
+1:
+  ldr w2, [x1, #0x18]          // UARTFR
+  tst w2, #(1 << 5)            // TXFF
+  b.ne 1b
+  str w0, [x1, #0x00]          // UARTDR
+  ret
+
+_start:
+  // Park secondary cores. (Pi firmware may start multiple cores.)
+  mrs x0, mpidr_el1
+  and x0, x0, #0xFF
+  cbz x0, 1f
+0:
+  wfe
+  b 0b
+1:
+  // Set an initial stack for the current EL.
+  ldr x0, =__boot_stack_top
+  mov sp, x0
+
+  // Detect current EL (bits [3:2]).
+  mrs x0, CurrentEL
+  lsr x0, x0, #2
+  and x0, x0, #3
+
+  // If we're already in EL1, skip the transition.
+  cmp x0, #1
+  b.eq el1_entry
+
+  // If we're in EL2, drop to EL1.
+  cmp x0, #2
+  b.ne .
+
+  // Marker: entering EL2->EL1 transition.
+  mov w0, #'2'
+  bl pl011_putc_early
+
+  // Configure EL2 so EL1 runs AArch64.
+  mov x0, #(1 << 31)           // HCR_EL2.RW=1
+  msr hcr_el2, x0
+
+  // Allow EL1 access to timers/counters; keep CNTV offset at 0.
+  mov x0, #3                   // CNTHCTL_EL2.EL1PCTEN|EL1PCEN
+  msr cnthctl_el2, x0
+  msr cntvoff_el2, xzr
+
+  // Disable FP traps from EL1.
+  msr cptr_el2, xzr
+
+  // Set EL1 stack pointer for after eret.
+  ldr x0, =__boot_stack_top
+  msr sp_el1, x0
+
+  // Return to EL1h with interrupts masked.
+  mov x0, #(0x3C0 | 0x5)        // DAIF=1111b, M=EL1h
+  msr spsr_el2, x0
+  adr x0, el1_entry
+  msr elr_el2, x0
+  isb
+  eret
+
+el1_entry:
+  // Marker: now executing in EL1.
+  mov w0, #'1'
+  bl pl011_putc_early
+
+  // Install vector base.
+  adr x1, __vec_base
+  msr VBAR_EL1, x1
+  isb
+
+  // Clear .bss.
+  ldr x1, =__bss_start
+  ldr x2, =__bss_end
+  cmp x1, x2
+  b.hs 2f
+1:
+  str xzr, [x1], #8
+  cmp x1, x2
+  b.lo 1b
+2:
+
+  // Enable FP/ASIMD at EL1/EL0.
+  mrs x3, cpacr_el1
+  orr x3, x3, #(0b11 << 20)
+  msr cpacr_el1, x3
+  isb
+
+  bl kmain
+
+3:
+  wfe
+  b 3b

--- a/boot/vectors.S
+++ b/boot/vectors.S
@@ -32,7 +32,7 @@ __vec_base:
   .balign 0x80                // SError EL0_64
   b sync_el0_64
 
-  // --- IRQ frame layout 與 irq_el1 保持原樣 ---
+  // --- Keep IRQ frame layout and irq_el1 unchanged ---
   .equ IRQ_FRAME_SIZE, 192
   .equ IRQ_FRAME_X0, 0
   .equ IRQ_FRAME_X2, 16
@@ -103,7 +103,7 @@ irq_el1:
 
   .extern except_el1_sync
 
-// --- 極簡同步例外轉印到 C ---
+// --- Minimal synchronous exception trampoline to C ---
 sync_el1h:
   mrs x0, esr_el1
   mrs x1, elr_el1

--- a/docs/rpi4.md
+++ b/docs/rpi4.md
@@ -1,0 +1,93 @@
+# Raspberry Pi 4 bring-up (AArch64)
+
+This repo primarily targets QEMU `-machine virt`, but also contains an initial
+Raspberry Pi 4 (BCM2711) bring-up path.
+
+## Build artifacts
+
+- `make rpi4` produces:
+  - `build/kernel8.img` (raw image for the Pi firmware)
+  - `build/kernel_rpi4.elf` (debuggable ELF)
+
+## Hardware checklist
+
+- Raspberry Pi 4 Model B
+- microSD card + reader
+- USB-to-TTL serial adapter (3.3V logic; **do not use 5V**)
+- Jumper wires
+
+## UART wiring (GPIO14/15)
+
+- Pi GPIO14 (TXD0) -> USB-TTL RX
+- Pi GPIO15 (RXD0) -> USB-TTL TX
+- Pi GND -> USB-TTL GND
+
+Serial settings: `115200 8N1`.
+
+## SD card layout
+
+On the boot FAT partition:
+
+- `config.txt`
+- `kernel8.img` (from `build/kernel8.img`)
+
+## Minimal `config.txt`
+
+This uses PL011 UART0 on GPIO14/15 by disabling Bluetooth.
+
+```ini
+arm_64bit=1
+enable_uart=1
+dtoverlay=disable-bt
+```
+
+If you see garbled output, the UART clock assumption may not match your
+firmware configuration. You can either adjust the firmware clock (advanced), or
+rebuild with a different clock value:
+
+```sh
+make rpi4 RPI4_UART_CLOCK_HZ=48000000
+```
+
+## First expected output
+
+The kernel should print at least:
+
+- `[BOOT] UART ready`
+
+The RPi4 boot stub also attempts to print a single character before and after
+the EL2→EL1 transition (`2` then `1`). These are best-effort and may be silent
+depending on firmware GPIO/UART setup.
+
+## macOS serial console
+
+Find the device:
+
+```sh
+ls /dev/tty.usbserial*
+```
+
+Connect:
+
+```sh
+screen /dev/tty.usbserial-XXXX 115200
+```
+
+Exit `screen`: `Ctrl-A` then `k`.
+
+## Current limitations
+
+- The RPi4 build halts after early init because the BCM2711 interrupt
+  controller is not wired up yet (`platform_full_kernel_supported()==0`).
+- QEMU virt remains the fully-supported platform for IRQ/timer/scheduler/DMA CI.
+
+## Troubleshooting
+
+- No output:
+  - Double-check wiring (TX/RX swapped is common).
+  - Ensure `dtoverlay=disable-bt` is present (otherwise PL011 may be used by BT).
+  - Confirm you are using 3.3V TTL (not RS-232 levels).
+- Garbled output:
+  - Confirm `115200 8N1`.
+  - Rebuild with `make rpi4 RPI4_UART_CLOCK_HZ=...`.
+

--- a/include/arch/cpu_local.h
+++ b/include/arch/cpu_local.h
@@ -6,7 +6,7 @@ struct Thread;
 
 struct alignas(64) cpu_local {
   uintptr_t irq_stack_top;   // points to __irq_stack_cpu0_top for CPU0
-  Thread*   current_thread;  // 目前執行緒
+  Thread*   current_thread;  // currently running thread
   unsigned  preempt_cnt;     // preemption nesting counter
   unsigned  need_resched;    // scheduler should pick another thread
   unsigned long ticks;       // timer tick counter

--- a/include/arch/ctx.h
+++ b/include/arch/ctx.h
@@ -2,10 +2,10 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-// 交換執行緒堆疊指標：*prev_sp 存回舊 sp，切換到 next_sp
+// Swap thread stack pointers: stores old sp into *prev_sp and switches to next_sp.
 void arch_switch(void** prev_sp, void* next_sp);
-// 首次切入新執行緒用的 thunk：讀取 cpu_local()->current_thread，
-// 呼叫其 entry(arg)，返回時呼叫 thread_exit() 結束。
+// Entry thunk for the first switch into a new thread: reads cpu_local()->current_thread,
+// calls entry(arg), and calls thread_exit() when it returns.
 void thread_trampoline(void);
 #ifdef __cplusplus
 }

--- a/include/platform.h
+++ b/include/platform.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Platform identifier string (e.g. "virt", "rpi4").
+const char* platform_name(void);
+
+// Perform platform-specific setup needed before uart_init():
+// - set PL011 MMIO base/clock
+// - configure GPIO mux (if required)
+void platform_early_init(void);
+
+// Initialize the platform interrupt controller (if present).
+void platform_irq_init(void);
+
+// Return 1 if the build supports the full IRQ+timer+RR scheduler path.
+// RPi4 bring-up starts in a UART-only mode until its IRQ controller support is
+// implemented.
+int platform_full_kernel_supported(void);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/include/thread.h
+++ b/include/thread.h
@@ -3,24 +3,24 @@
 #include <stdint.h>
 
 struct Thread {
-  void*      sp;         // 保存的 stack pointer（arch_switch 用）
+  void*      sp;         // saved stack pointer (used by arch_switch)
   void     (*entry)(void*);
   void*      arg;
-  Thread*    next;       // 單向循環佇列
+  Thread*    next;       // singly-linked circular runqueue
   int        id;
-  void*      stack_base; // for free/debug (暫不釋放)
+  void*      stack_base; // for debug (not freed yet)
   size_t     stack_size;
-  int        budget;     // 剩餘時間片（tick 數）
+  int        budget;     // remaining time slice (ticks)
 
   // ---- FPSIMD context ----
-  int        fpsimd_valid;                 // 0 = 未保存/初值為零, 1 = 已有有效內容
-  alignas(16) uint8_t fpsimd_vregs[32*16]; // q0..q31 共 512 bytes
+  int        fpsimd_valid;                 // 0 = never saved / initial zeros, 1 = valid saved state
+  alignas(16) uint8_t fpsimd_vregs[32*16]; // q0..q31 (512 bytes)
   uint64_t   fpcr;                         // FPCR
   uint64_t   fpsr;                         // FPSR
 };
 
 #ifdef __cplusplus
-// 保證 ctx.S / thread_trampoline 以固定 offset 取欄位時不會出事
+// Ensure ctx.S / thread_trampoline can rely on stable field offsets.
 static_assert(offsetof(Thread, sp)    == 0,  "Thread::sp must be at +0");
 static_assert(offsetof(Thread, entry) == 8,  "Thread::entry must be at +8");
 static_assert(offsetof(Thread, arg)   == 16, "Thread::arg must be at +16");
@@ -32,8 +32,8 @@ extern "C" {
 void  sched_init(void);
 Thread* thread_create(void (*entry)(void*), void* arg, size_t stack_size);
 void  sched_add(Thread* t);
-void  sched_start(void);   // 切入第一個 thread（不可返回）
-void  thread_yield(void);  // cooperative 切換至下一個
+void  sched_start(void);   // enter the first thread (never returns)
+void  thread_yield(void);  // cooperative switch to next thread
 __attribute__((noreturn)) void thread_exit(void);
 void  sched_resched_from_irq_tail(void);
 void  sched_on_tick(void);

--- a/scripts/smoke_run.sh
+++ b/scripts/smoke_run.sh
@@ -108,7 +108,7 @@ if grep -qF "[EXC]" "${LOG_PATH}"; then
   exit 1
 fi
 
-# 基本啟動訊息
+# Basic boot messages
 required_messages=(
   "[BOOT] UART ready"
   "[mmu] enabled"
@@ -129,7 +129,7 @@ if ! grep -Eq '\[dma-policy\][[:space:]]+(CACHEABLE|NONCACHEABLE)([[:space:]]|$)
 fi
 echo "[smoke] Boot messages OK."
 
-# IRQ 信標與心跳檢查
+# IRQ beacon and heartbeat checks
 flat_log=$(tr -d $'\n' < "${LOG_PATH}")
 if ! grep -qF '!' "${LOG_PATH}"; then
   echo "::error ::No IRQ entries seen ('!'): check GIC init or msr daifclr,#2"
@@ -144,7 +144,7 @@ if ! printf '%s' "${flat_log}" | grep -q '\.'; then
   exit 1
 fi
 
-# RR/搶佔輸出
+# RR / preemption output
 if ! printf '%s' "${flat_log}" | grep -q 'A.*a'; then
   echo "::error ::Missing expected scheduler evidence: A then a (interleaving allowed)"
   exit 1
@@ -163,7 +163,7 @@ if ! printf '%s' "${flat_log}" | grep -q 'a[^b]*a'; then
 fi
 echo "[smoke] Scheduler output verified."
 
-# DMA 驗收（一定要看到）
+# DMA validation (must see)
 if grep -qF "[DMA FAIL]" "${LOG_PATH}"; then
   echo "::error ::DMA self-test reported failure"
   exit 1

--- a/src/arch/aarch64/except.cc
+++ b/src/arch/aarch64/except.cc
@@ -17,7 +17,7 @@ static void puthex32(uint32_t v){
 }
 static const char* ec_name(uint32_t ec){
   switch(ec){
-    case 0x07: return "FP/ASIMD trap";   // <== 新增：對應 ESR EC=0x07
+    case 0x07: return "FP/ASIMD trap";   // ESR EC=0x07
     case 0x15: return "SVC64";
     case 0x18: return "IABT";
     case 0x24: return "DABT";

--- a/src/arch/aarch64/fpsimd.cc
+++ b/src/arch/aarch64/fpsimd.cc
@@ -4,8 +4,11 @@
 
 #include <stdint.h>
 
-// 這份實作不做 lazy enable，因為我們已在 boot/start.S 打開 CPACR_EL1.FPEN=0b11。
-// 注意：本檔會用到 q0..q31 指令，請勿用 -mgeneral-regs-only 編譯本檔。
+// This implementation does not do lazy enable because boot/start.S already sets
+// CPACR_EL1.FPEN=0b11.
+//
+// NOTE: This file uses q0..q31 instructions; do not compile it with
+// -mgeneral-regs-only.
 
 extern "C" void fpsimd_save(void) {
   auto* cpu = cpu_local();
@@ -50,7 +53,8 @@ extern "C" void fpsimd_load(void) {
   if (!cpu || !cpu->current_thread) return;
   Thread* t = cpu->current_thread;
 
-  // 若尚未存過，先清零 q-reg（保險；一般情況 thread 剛建立時為 0）
+  // If the thread hasn't saved FPSIMD state yet, clear q-regs (defensive; new
+  // threads typically start at zero anyway).
   if (!t->fpsimd_valid) {
     asm volatile(
         "eor v0.16b,  v0.16b,  v0.16b\n\t"

--- a/src/arch/aarch64/mmu_rpi4.cc
+++ b/src/arch/aarch64/mmu_rpi4.cc
@@ -1,0 +1,238 @@
+#include "arch/mmu.h"
+
+#include <stdint.h>
+#include "arch/barrier.h"
+#include "drivers/uart_pl011.h"
+
+namespace {
+constexpr char kHexDigits[] = "0123456789abcdef";
+
+static void puthex64(uint64_t v) {
+  if (!v) { uart_putc('0'); return; }
+  char b[16]; int i = 0;
+  while (v && i < 16) { b[i++] = kHexDigits[v & 0xF]; v >>= 4; }
+  while (i--) uart_putc(b[i]);
+}
+
+static inline uint64_t read_sctlr_el1() {
+  uint64_t v = 0;
+  asm volatile("mrs %0, sctlr_el1" : "=r"(v));
+  return v;
+}
+
+static inline uint64_t read_id_aa64mmfr0_el1() {
+  uint64_t v = 0;
+  asm volatile("mrs %0, id_aa64mmfr0_el1" : "=r"(v));
+  return v;
+}
+
+static inline void write_mair_el1(uint64_t v) { asm volatile("msr mair_el1, %0" :: "r"(v)); }
+static inline void write_tcr_el1(uint64_t v)  { asm volatile("msr tcr_el1, %0" :: "r"(v)); }
+static inline void write_ttbr0_el1(uint64_t v){ asm volatile("msr ttbr0_el1, %0" :: "r"(v)); }
+static inline void write_sctlr_el1(uint64_t v){ asm volatile("msr sctlr_el1, %0" :: "r"(v)); }
+
+static inline void tlbi_vmalle1() { asm volatile("tlbi vmalle1"); }
+static inline void ic_iallu() { asm volatile("ic iallu"); }
+
+constexpr uint64_t kAttrIdxNormal = 0;
+constexpr uint64_t kAttrIdxDevice = 1;
+constexpr uint64_t kAttrIdxNormalNc = 2;
+
+constexpr uint64_t kMairAttrNormalWbWa = 0xFF;  // Outer+Inner WBWA.
+constexpr uint64_t kMairAttrDevice_nGnRE = 0x04;
+constexpr uint64_t kMairAttrNormalNc = 0x44;    // Outer+Inner Non-cacheable.
+
+static inline uint64_t mair_value() {
+  return (kMairAttrNormalWbWa << (8 * kAttrIdxNormal)) |
+         (kMairAttrDevice_nGnRE << (8 * kAttrIdxDevice)) |
+         (kMairAttrNormalNc << (8 * kAttrIdxNormalNc));
+}
+
+static inline uint64_t tcr_value() {
+  const uint64_t mmfr0 = read_id_aa64mmfr0_el1();
+  uint64_t parange = mmfr0 & 0xFULL;
+  if (parange > 6) parange = 5;  // Fallback to 48-bit.
+
+  // T0SZ=16 => 48-bit VA, 4KB granule, Inner Shareable, WBWA table walks.
+  uint64_t tcr = 0;
+  tcr |= 16ull;                // T0SZ[5:0]
+  tcr |= (1ull << 23);         // EPD1: disable TTBR1 walks
+  tcr |= (1ull << 8);          // IRGN0[9:8] = 0b01 (WBWA)
+  tcr |= (1ull << 10);         // ORGN0[11:10] = 0b01 (WBWA)
+  tcr |= (3ull << 12);         // SH0[13:12] = 0b11 (Inner Shareable)
+  tcr |= (0ull << 14);         // TG0[15:14] = 0b00 (4KB)
+  tcr |= (parange << 32);      // IPS[34:32]
+  return tcr;
+}
+
+static inline uint64_t pte_table(uint64_t next_table_phys) {
+  return (next_table_phys & 0x0000FFFFFFFFF000ull) | 0b11ull;
+}
+
+static inline uint64_t pte_block(uint64_t phys_base, uint64_t attr_index, uint64_t sh) {
+  constexpr uint64_t kAf = 1ull << 10;
+  constexpr uint64_t kApKernelRw = 0ull << 6;  // EL1 RW, EL0 no access.
+  return (phys_base & 0x0000FFFFFFFFF000ull) |
+         0b01ull |
+         (attr_index << 2) |
+         kApKernelRw |
+         (sh << 8) |
+         kAf;
+}
+
+static inline uint64_t pte_page(uint64_t phys_base, uint64_t attr_index, uint64_t sh) {
+  constexpr uint64_t kAf = 1ull << 10;
+  constexpr uint64_t kApKernelRw = 0ull << 6;  // EL1 RW, EL0 no access.
+  return (phys_base & 0x0000FFFFFFFFF000ull) |
+         0b11ull |
+         (attr_index << 2) |
+         kApKernelRw |
+         (sh << 8) |
+         kAf;
+}
+
+alignas(4096) static uint64_t g_l0[512];
+alignas(4096) static uint64_t g_l1[512];
+alignas(4096) static uint64_t g_l2_lowram[512];
+alignas(4096) static uint64_t g_l3_dma0[512];
+alignas(4096) static uint64_t g_l3_dma1[512];
+
+extern "C" {
+extern char __dma_nc_start[];
+extern char __dma_nc_end[];
+}
+
+constexpr uintptr_t kL1BlockSize = 1ull << 30;  // 1GB
+constexpr uintptr_t kL2BlockSize = 1ull << 21;  // 2MB
+constexpr uintptr_t kPageSize = 1ull << 12;     // 4KB
+
+// Pi4 peripherals live at the top of the first 4GB (0xFE000000..).
+constexpr uintptr_t kPeriphL1Base = 0xC0000000ull;  // 3GB-aligned (L1 index 3)
+
+#if defined(DMA_WINDOW_POLICY_NONCACHEABLE) && defined(DMA_WINDOW_POLICY_CACHEABLE)
+#error "Define only one of DMA_WINDOW_POLICY_{CACHEABLE,NONCACHEABLE}"
+#endif
+#if !defined(DMA_WINDOW_POLICY_NONCACHEABLE) && !defined(DMA_WINDOW_POLICY_CACHEABLE)
+#define DMA_WINDOW_POLICY_CACHEABLE 1
+#endif
+
+static void build_map() {
+  for (unsigned i = 0; i < 512; ++i) {
+    g_l0[i] = 0;
+    g_l1[i] = 0;
+    g_l2_lowram[i] = 0;
+    g_l3_dma0[i] = 0;
+    g_l3_dma1[i] = 0;
+  }
+
+  constexpr uint64_t kPtePxN = 1ull << 53;
+  constexpr uint64_t kPteUxN = 1ull << 54;
+
+  g_l0[0] = pte_table(static_cast<uint64_t>(reinterpret_cast<uintptr_t>(g_l1)));
+
+  // VA 0x00000000..0x3FFFFFFF: low RAM (identity, cacheable) via L2.
+  g_l1[0] = pte_table(static_cast<uint64_t>(reinterpret_cast<uintptr_t>(g_l2_lowram)));
+
+  // VA 0x40000000..0x7FFFFFFF: non-cacheable alias of low RAM (for lab/device view).
+  g_l1[1] = pte_block(/*phys*/0x00000000ull, kAttrIdxNormalNc, /*SH*/3) | kPtePxN | kPteUxN;
+
+  // VA 0xC0000000..0xFFFFFFFF: peripherals (Device-nGnRE).
+  g_l1[3] = pte_block(static_cast<uint64_t>(kPeriphL1Base), kAttrIdxDevice, /*SH*/0) | kPtePxN | kPteUxN;
+
+  for (unsigned i = 0; i < 512; ++i) {
+    uint64_t pa = static_cast<uint64_t>(i) * static_cast<uint64_t>(kL2BlockSize);
+    g_l2_lowram[i] = pte_block(pa, kAttrIdxNormal, /*SH*/3);
+  }
+
+  const uintptr_t dma_start = reinterpret_cast<uintptr_t>(__dma_nc_start);
+  const uintptr_t dma_end = reinterpret_cast<uintptr_t>(__dma_nc_end);
+  if (dma_end > dma_start) {
+    const uintptr_t dma_last = dma_end - 1u;
+    if ((dma_start / kL1BlockSize) == 0 && (dma_last / kL1BlockSize) == 0) {
+      uintptr_t dma_first_block = dma_start & ~(kL2BlockSize - 1u);
+      uintptr_t dma_last_block = dma_last & ~(kL2BlockSize - 1u);
+
+      uintptr_t blocks[2] = {dma_first_block, dma_last_block};
+      uint64_t* l3_tables[2] = {g_l3_dma0, g_l3_dma1};
+      unsigned table_count = (dma_first_block == dma_last_block) ? 1u : 2u;
+
+      for (unsigned t = 0; t < table_count; ++t) {
+        uintptr_t block_base = blocks[t];
+        unsigned l2_index = static_cast<unsigned>(block_base / kL2BlockSize);
+        uint64_t* l3 = l3_tables[t];
+
+        for (unsigned i = 0; i < 512; ++i) {
+          uintptr_t pa = block_base + (static_cast<uintptr_t>(i) * kPageSize);
+          uint64_t attr = kAttrIdxNormal;
+          uint64_t xn = 0;
+
+          if (pa >= dma_start && pa < dma_end) {
+            xn = kPtePxN | kPteUxN;
+#if defined(DMA_WINDOW_POLICY_NONCACHEABLE)
+            attr = kAttrIdxNormalNc;
+#endif
+          }
+          l3[i] = pte_page(static_cast<uint64_t>(pa), attr, /*SH*/3) | xn;
+        }
+
+        g_l2_lowram[l2_index] = pte_table(static_cast<uint64_t>(reinterpret_cast<uintptr_t>(l3)));
+      }
+    }
+  }
+
+  dsb_ish();
+}
+}  // namespace
+
+void mmu_dump_state() {
+  uint64_t mair = 0, tcr = 0, ttbr0 = 0, sctlr = 0;
+  asm volatile("mrs %0, mair_el1" : "=r"(mair));
+  asm volatile("mrs %0, tcr_el1" : "=r"(tcr));
+  asm volatile("mrs %0, ttbr0_el1" : "=r"(ttbr0));
+  asm volatile("mrs %0, sctlr_el1" : "=r"(sctlr));
+
+  uart_puts("[mmu] mair_el1=0x"); puthex64(mair); uart_puts("\n");
+  uart_puts("[mmu] tcr_el1 =0x"); puthex64(tcr); uart_puts("\n");
+  uart_puts("[mmu] ttbr0_el1=0x"); puthex64(ttbr0); uart_puts("\n");
+  uart_puts("[mmu] sctlr=0x"); puthex64(sctlr);
+  uart_puts(" (C="); uart_putc((sctlr & (1u << 2)) ? '1' : '0');
+  uart_puts(", I="); uart_putc((sctlr & (1u << 12)) ? '1' : '0');
+  uart_puts(", M="); uart_putc((sctlr & (1u << 0)) ? '1' : '0');
+  uart_puts(")\n");
+}
+
+void mmu_init(bool enable) {
+  if (!enable) {
+    return;
+  }
+
+  const uint64_t before = read_sctlr_el1();
+  if (before & 1u) {
+    // Already enabled; keep current regime.
+    return;
+  }
+
+  build_map();
+
+  write_mair_el1(mair_value());
+  write_tcr_el1(tcr_value());
+  write_ttbr0_el1(static_cast<uint64_t>(reinterpret_cast<uintptr_t>(g_l0)));
+  isb();
+
+  dsb_ish();
+  tlbi_vmalle1();
+  dsb_ish();
+  isb();
+
+  ic_iallu();
+  dsb_ish();
+  isb();
+
+  uint64_t sctlr = before;
+  sctlr |= (1ull << 0);   // M: MMU enable
+  sctlr |= (1ull << 2);   // C: data cache enable
+  sctlr |= (1ull << 12);  // I: instruction cache enable
+  write_sctlr_el1(sctlr);
+  isb();
+}
+

--- a/src/drivers/uart_pl011.cc
+++ b/src/drivers/uart_pl011.cc
@@ -1,25 +1,59 @@
 #include "drivers/uart_pl011.h"
 
-void uart_init() {
-  // disable before config
-  mmio_write(UART0_BASE + UARTCR, 0x0);
-  mmio_write(UART0_BASE + UARTIMSC, 0x0);
+namespace {
+uint64_t g_uart_base = 0x09000000ull;
+uint32_t g_uart_clock_hz = 24000000u;
+}  // namespace
 
-  // 24MHz / (16 * 115200) ≈ 13.02 -> IBRD=13, FBRD≈27
-  mmio_write(UART0_BASE + UARTIBRD, 13);
-  mmio_write(UART0_BASE + UARTFBRD, 27);
+void uart_pl011_set_mmio_base(uint64_t base) {
+  g_uart_base = base;
+}
+
+void uart_pl011_set_clock_hz(uint32_t hz) {
+  g_uart_clock_hz = hz;
+}
+
+uint64_t uart_pl011_mmio_base(void) {
+  return g_uart_base;
+}
+
+uint32_t uart_pl011_clock_hz(void) {
+  return g_uart_clock_hz;
+}
+
+void uart_init() {
+  const uint64_t base = uart_pl011_mmio_base();
+  const uint32_t uartclk = uart_pl011_clock_hz() ? uart_pl011_clock_hz() : 24000000u;
+  constexpr uint32_t baud = 115200u;
+
+  // disable before config
+  mmio_write(base + UARTCR, 0x0);
+  mmio_write(base + UARTIMSC, 0x0);
+
+  // BaudDiv = UARTCLK/(16*BAUD). PL011 registers store it as IBRD + FBRD/64.
+  // BaudDiv*64 = UARTCLK*4/BAUD.
+  uint64_t bauddiv_x64 = ((uint64_t)uartclk * 4ull + (baud / 2u)) / baud;
+  uint32_t ibrd = static_cast<uint32_t>(bauddiv_x64 / 64ull);
+  uint32_t fbrd = static_cast<uint32_t>(bauddiv_x64 % 64ull);
+  if (ibrd == 0) {
+    ibrd = 1;
+  }
+
+  mmio_write(base + UARTIBRD, ibrd);
+  mmio_write(base + UARTFBRD, fbrd);
 
   // FIFO enable, 8 data bits, 1 stop, no parity
-  mmio_write(UART0_BASE + UARTLCR_H, (1u<<4) | (3u<<5));
+  mmio_write(base + UARTLCR_H, (1u<<4) | (3u<<5));
 
   // enable UART, TX, RX
-  mmio_write(UART0_BASE + UARTCR, (1u<<0) | (1u<<8) | (1u<<9));
+  mmio_write(base + UARTCR, (1u<<0) | (1u<<8) | (1u<<9));
 }
 
 void uart_putc(char c) {
+  const uint64_t base = uart_pl011_mmio_base();
   // wait while TX FIFO full
-  while (mmio_read(UART0_BASE + UARTFR) & (1u<<5)) { }
-  mmio_write(UART0_BASE + UARTDR, (uint32_t)c);
+  while (mmio_read(base + UARTFR) & (1u<<5)) { }
+  mmio_write(base + UARTDR, (uint32_t)c);
 }
 
 void uart_puts(const char* s) {

--- a/src/drivers/uart_pl011.h
+++ b/src/drivers/uart_pl011.h
@@ -1,7 +1,7 @@
 
 #pragma once
 #include <stdint.h>
-#define UART0_BASE   0x09000000UL
+
 #define UARTDR       0x00
 #define UARTFR       0x18
 #define UARTIBRD     0x24
@@ -11,6 +11,13 @@
 #define UARTIMSC     0x38
 static inline void mmio_write(uint64_t addr, uint32_t val){ *(volatile uint32_t*)(addr)=val; }
 static inline uint32_t mmio_read(uint64_t addr){ return *(volatile uint32_t*)(addr); }
+
+// Platform-provided configuration. Defaults are set for QEMU virt.
+void uart_pl011_set_mmio_base(uint64_t base);
+void uart_pl011_set_clock_hz(uint32_t hz);
+uint64_t uart_pl011_mmio_base(void);
+uint32_t uart_pl011_clock_hz(void);
+
 void uart_init();
 void uart_putc(char c);
 void uart_puts(const char* s);

--- a/src/kmain.cc
+++ b/src/kmain.cc
@@ -1,12 +1,12 @@
 #include <stdint.h>
 #include "drivers/uart_pl011.h"
 #include "arch/cpu_local.h"
-#include "arch/gicv3.h"
 #include "arch/timer.h"
 #include "arch/irqflags.h"
 #include "arch/ctx.h"
 #include "arch/mmu.h"
 #include "kmem.h"
+#include "platform.h"
 #include "thread.h"
 #include "preempt.h"
 #include "dma.h"
@@ -67,6 +67,7 @@ static void dma_test_cb(void* user, int status) {
 }
 
 extern "C" void kmain() {
+  platform_early_init();
   uart_init();
   uart_puts("[BOOT] UART ready\n");
 
@@ -94,6 +95,13 @@ extern "C" void kmain() {
   uart_puts("[build] "); uart_puts(__DATE__); uart_puts(" "); uart_puts(__TIME__); uart_puts("\n");
 
   uart_puts("[dma-policy] "); uart_puts(DMA_WINDOW_POLICY_STR); uart_puts("\n");
+#if !DMA_LAB_MODE
+  if (!platform_full_kernel_supported()) {
+    uart_puts("[platform] "); uart_puts(platform_name());
+    uart_puts(" bring-up: IRQ controller not enabled yet; halting\n");
+    while (1) { asm volatile("wfe"); }
+  }
+#endif
 #if DMA_LAB_MODE
   uart_puts("[dma-lab] mode="); uart_print_u64(static_cast<unsigned long long>(DMA_LAB_MODE)); uart_puts("\n");
   dma_lab_run(static_cast<unsigned>(DMA_LAB_MODE));
@@ -166,7 +174,7 @@ extern "C" void kmain() {
   uart_puts("[sched] starting (coop)\n");
 
   uart_puts("[diag] gic_init\n");
-  gic_init();
+  platform_irq_init();
 
   uart_puts("[diag] timer_init_hz\n");
   timer_init_hz(1000);

--- a/src/kmain.cc
+++ b/src/kmain.cc
@@ -91,7 +91,7 @@ extern "C" void kmain() {
   kmem_init();
   uart_puts("[diag] kmem_init end\n");
 
-  // 構建指紋 (timestamp)
+  // Build fingerprint (timestamp)
   uart_puts("[build] "); uart_puts(__DATE__); uart_puts(" "); uart_puts(__TIME__); uart_puts("\n");
 
   uart_puts("[dma-policy] "); uart_puts(DMA_WINDOW_POLICY_STR); uart_puts("\n");

--- a/src/platform/rpi4.cc
+++ b/src/platform/rpi4.cc
@@ -1,0 +1,61 @@
+#include "platform.h"
+
+#include <stdint.h>
+
+#include "drivers/uart_pl011.h"
+
+namespace {
+constexpr uintptr_t kPeriphBase = 0xFE000000ull;
+constexpr uintptr_t kGpioBase = kPeriphBase + 0x200000u;
+
+constexpr uintptr_t kGpfsel1 = kGpioBase + 0x04u;
+constexpr uintptr_t kGppupdn0 = kGpioBase + 0xE4u;
+
+constexpr uintptr_t kUart0Base = kPeriphBase + 0x201000u;
+
+#if defined(RPI4_UART_CLOCK_HZ)
+constexpr uint32_t kUart0ClockHz = static_cast<uint32_t>(RPI4_UART_CLOCK_HZ);
+#else
+constexpr uint32_t kUart0ClockHz = 48000000u;
+#endif
+
+static inline void mmio_write32(uintptr_t addr, uint32_t v) {
+  *reinterpret_cast<volatile uint32_t*>(addr) = v;
+}
+
+static inline uint32_t mmio_read32(uintptr_t addr) {
+  return *reinterpret_cast<volatile uint32_t*>(addr);
+}
+
+static void gpio_init_pl011_uart0(void) {
+  // GPIO14/15 -> ALT0 (PL011 TXD0/RXD0).
+  uint32_t fsel1 = mmio_read32(kGpfsel1);
+  fsel1 &= ~((7u << 12) | (7u << 15));
+  fsel1 |= (4u << 12) | (4u << 15);
+  mmio_write32(kGpfsel1, fsel1);
+
+  // BCM2711 uses GPPUPPDN registers: 00 = no pull.
+  uint32_t pupdn0 = mmio_read32(kGppupdn0);
+  pupdn0 &= ~((3u << 28) | (3u << 30));
+  mmio_write32(kGppupdn0, pupdn0);
+}
+}  // namespace
+
+extern "C" const char* platform_name(void) {
+  return "rpi4";
+}
+
+extern "C" void platform_early_init(void) {
+  // NOTE: RPi4 UART clocks can vary based on firmware config; see docs.
+  uart_pl011_set_mmio_base(kUart0Base);
+  uart_pl011_set_clock_hz(kUart0ClockHz);
+  gpio_init_pl011_uart0();
+}
+
+extern "C" void platform_irq_init(void) {
+  // TODO: BCM2711 interrupt controller (RPi4) bring-up.
+}
+
+extern "C" int platform_full_kernel_supported(void) {
+  return 0;
+}

--- a/src/platform/virt.cc
+++ b/src/platform/virt.cc
@@ -1,0 +1,23 @@
+#include "platform.h"
+
+#include "arch/gicv3.h"
+#include "drivers/uart_pl011.h"
+
+extern "C" const char* platform_name(void) {
+  return "virt";
+}
+
+extern "C" void platform_early_init(void) {
+  // QEMU virt uses a PL011 at 0x0900_0000. The clock is typically 24 MHz.
+  uart_pl011_set_mmio_base(0x09000000ull);
+  uart_pl011_set_clock_hz(24000000u);
+}
+
+extern "C" void platform_irq_init(void) {
+  gic_init();
+}
+
+extern "C" int platform_full_kernel_supported(void) {
+  return 1;
+}
+


### PR DESCRIPTION
## PR Description

### 📝 Summary

This PR introduces a minimal platform abstraction layer and adds a build path for **Raspberry Pi 4 (RPi4)** bring-up. It ensures the existing QEMU `virt` workflow and CI smoke tests remain unaffected.

### 🛠 Key Changes

**Platform Abstraction & Drivers**

* **Core Layer:** Introduced `platform.h` along with specific implementations in `virt.cc` and `rpi4.cc`.
* **UART:** Genericized PL011 UART configuration in `uart_pl011.h` / `.cc` (base address and clock are now set by the platform).

**RPi4 Build & Boot**

* **Boot Flow:** Added `rpi4_start.S` and linker script `kernel_rpi4.ld`.
* **Build Target:** Updated `Makefile`. Running `make rpi4` now emits `kernel8.img` and `kernel_rpi4.elf`.
* **Memory Management:** Implemented RPi4 MMU/cache mapping skeleton in `mmu_rpi4.cc` (mapped peripherals as `Device-nGnRE`).

**Documentation & Cleanup**

* **Docs:** Added `rpi4.md` and expanded `README.md` with STAR design narratives.
* **Refactoring:**
* `dma_lab.cc`: Removed emojis for cleaner logs.
* `Makefile`: Pinned standard to `-std=c++17`.



### 🧪 How to Test

1. **Regression Test (QEMU virt):**
Ensure existing workflow passes:
```bash
./smoke_run.sh

```


2. **RPi4 Image Build:**
Build the new target:
```bash
make rpi4
# Optional clock override:
# make rpi4 RPI4_UART_CLOCK_HZ=48000000

```



### ⚠️ Known Limitations

* **Early Init Only:** The RPi4 target currently halts after early initialization because the **BCM2711 interrupt controller** path is not implemented yet.
* `platform_full_kernel_supported()` currently returns `0`.
* **Current Milestone:** UART boot logs + MMU/caches scaffolding only.

### 📜 Commits Included

* `fae2486` feat(rpi4): add bring-up scaffolding
* `45f8343` chore: remove emojis from dma lab logs
* `40f138e` build: pin C++ standard to c++17
* `54a7b67` docs: translate Chinese to English and expand README

---
