### PR TITLE
feat(sync): add PRIO scheduler + mutex/semaphore + priority-inheritance lab

### DIFF
--- a/include/sync.h
+++ b/include/sync.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "thread.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// A simple non-recursive mutex with optional priority inheritance.
+struct mutex {
+  Thread* owner;
+  Thread* waiters;      // wait-queue (Thread::wait_next)
+  mutex*  owner_next;   // link in Thread::owned_mutexes
+  int     pi_enabled;
+};
+
+void mutex_init(mutex* m);
+void mutex_set_pi_enabled(mutex* m, int enabled);
+void mutex_lock(mutex* m);
+void mutex_unlock(mutex* m);
+
+// Counting semaphore.
+struct semaphore {
+  int     count;        // may become negative while waiters exist
+  Thread* waiters;      // wait-queue (Thread::wait_next)
+};
+
+void sem_init(semaphore* s, int initial_count);
+void sem_down(semaphore* s);
+void sem_up(semaphore* s);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/include/sync_lab.h
+++ b/include/sync_lab.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Priority inversion lab:
+// - mode=1: demonstrate inversion, then enable PI and recover (expected PASS)
+void sync_lab_setup(unsigned mode);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/src/sync.cc
+++ b/src/sync.cc
@@ -1,0 +1,223 @@
+#include "sync.h"
+
+#include "arch/cpu_local.h"
+#include "drivers/uart_pl011.h"
+#include "preempt.h"
+
+namespace {
+#ifndef MUTEX_PI
+#define MUTEX_PI 1
+#endif
+
+static Thread* waitq_pop_highest(Thread** head) {
+  if (!head || !*head) return nullptr;
+
+  Thread* best_prev = nullptr;
+  Thread* best = *head;
+  int best_prio = thread_effective_priority(best);
+
+  Thread* prev = nullptr;
+  for (Thread* t = *head; t; t = t->wait_next) {
+    int prio = thread_effective_priority(t);
+    if (prio > best_prio) {
+      best_prio = prio;
+      best_prev = prev;
+      best = t;
+    }
+    prev = t;
+  }
+
+  if (best_prev) {
+    best_prev->wait_next = best->wait_next;
+  } else {
+    *head = best->wait_next;
+  }
+  best->wait_next = nullptr;
+  return best;
+}
+
+static int waitq_max_priority(Thread* head) {
+  int best = -1;
+  for (Thread* t = head; t; t = t->wait_next) {
+    int prio = thread_effective_priority(t);
+    if (prio > best) best = prio;
+  }
+  return best;
+}
+
+static void thread_owned_mutex_add(Thread* t, mutex* m) {
+  if (!t || !m) return;
+  m->owner_next = t->owned_mutexes;
+  t->owned_mutexes = m;
+}
+
+static void thread_owned_mutex_remove(Thread* t, mutex* m) {
+  if (!t || !m) return;
+  mutex* prev = nullptr;
+  for (mutex* it = t->owned_mutexes; it; it = it->owner_next) {
+    if (it == m) {
+      if (prev) {
+        prev->owner_next = it->owner_next;
+      } else {
+        t->owned_mutexes = it->owner_next;
+      }
+      it->owner_next = nullptr;
+      return;
+    }
+    prev = it;
+  }
+}
+
+static void recompute_effective_priority(Thread* t) {
+  if (!t) return;
+  int eff = thread_base_priority(t);
+#if MUTEX_PI
+  for (mutex* m = t->owned_mutexes; m; m = m->owner_next) {
+    if (!m->pi_enabled) continue;
+    int w = waitq_max_priority(m->waiters);
+    if (w > eff) eff = w;
+  }
+#endif
+  thread_set_effective_priority(t, eff);
+}
+
+static void mutex_apply_pi(mutex* m) {
+  if (!m || !m->pi_enabled) return;
+  if (!m->owner) return;
+  recompute_effective_priority(m->owner);
+}
+}  // namespace
+
+extern "C" void mutex_init(mutex* m) {
+  if (!m) return;
+  m->owner = nullptr;
+  m->waiters = nullptr;
+  m->owner_next = nullptr;
+  m->pi_enabled = MUTEX_PI ? 1 : 0;
+}
+
+extern "C" void mutex_set_pi_enabled(mutex* m, int enabled) {
+  if (!m) return;
+  preempt_disable();
+  m->pi_enabled = enabled ? 1 : 0;
+  if (m->owner) {
+    recompute_effective_priority(m->owner);
+  }
+  preempt_enable();
+}
+
+extern "C" void mutex_lock(mutex* m) {
+  if (!m) return;
+
+  for (;;) {
+    preempt_disable();
+    auto* cpu = cpu_local();
+    Thread* cur = cpu ? cpu->current_thread : nullptr;
+    if (!cur) {
+      preempt_enable();
+      return;
+    }
+
+    if (m->owner == cur) {
+      // Already the owner (non-recursive mutex); treat as acquired.
+      preempt_enable();
+      return;
+    }
+
+    if (m->owner == nullptr) {
+      m->owner = cur;
+      thread_owned_mutex_add(cur, m);
+      preempt_enable();
+      return;
+    }
+
+    // Block.
+    cur->wait_next = m->waiters;
+    m->waiters = cur;
+    mutex_apply_pi(m);
+
+    sched_block_current();
+    cpu->need_resched = 1;
+    preempt_enable();
+  }
+}
+
+extern "C" void mutex_unlock(mutex* m) {
+  if (!m) return;
+
+  preempt_disable();
+  auto* cpu = cpu_local();
+  Thread* cur = cpu ? cpu->current_thread : nullptr;
+  if (!cur || m->owner != cur) {
+    preempt_enable();
+    return;
+  }
+
+  thread_owned_mutex_remove(cur, m);
+
+  Thread* next_owner = waitq_pop_highest(&m->waiters);
+  if (next_owner) {
+    m->owner = next_owner;
+    thread_owned_mutex_add(next_owner, m);
+    sched_make_runnable(next_owner);
+    mutex_apply_pi(m);
+  } else {
+    m->owner = nullptr;
+  }
+
+  recompute_effective_priority(cur);
+  if (next_owner && cpu && cpu->current_thread == cur &&
+      thread_effective_priority(next_owner) > thread_effective_priority(cur)) {
+    cpu->need_resched = 1;
+  }
+  preempt_enable();
+}
+
+extern "C" void sem_init(semaphore* s, int initial_count) {
+  if (!s) return;
+  s->count = initial_count;
+  s->waiters = nullptr;
+}
+
+extern "C" void sem_down(semaphore* s) {
+  if (!s) return;
+  preempt_disable();
+  s->count--;
+  if (s->count >= 0) {
+    preempt_enable();
+    return;
+  }
+
+  auto* cpu = cpu_local();
+  Thread* cur = cpu ? cpu->current_thread : nullptr;
+  if (!cur) {
+    preempt_enable();
+    return;
+  }
+
+  cur->wait_next = s->waiters;
+  s->waiters = cur;
+  sched_block_current();
+  cpu->need_resched = 1;
+  preempt_enable();
+}
+
+extern "C" void sem_up(semaphore* s) {
+  if (!s) return;
+  preempt_disable();
+
+  s->count++;
+  if (s->count <= 0) {
+    Thread* t = waitq_pop_highest(&s->waiters);
+    if (t) {
+      sched_make_runnable(t);
+      auto* cpu = cpu_local();
+      if (cpu && cpu->current_thread &&
+          thread_effective_priority(t) > thread_effective_priority(cpu->current_thread)) {
+        cpu->need_resched = 1;
+      }
+    }
+  }
+
+  preempt_enable();
+}

--- a/src/sync_lab.cc
+++ b/src/sync_lab.cc
@@ -1,0 +1,121 @@
+#include "sync_lab.h"
+
+#include <stdint.h>
+
+#include "arch/cpu_local.h"
+#include "drivers/uart_pl011.h"
+#include "preempt.h"
+#include "sync.h"
+#include "thread.h"
+
+namespace {
+mutex g_lock;
+semaphore g_start;
+
+volatile int g_pi_enabled = 0;
+volatile int g_high_done = 0;
+
+static inline void spin(unsigned n) {
+  for (volatile unsigned i = 0; i < n; ++i) {
+    asm volatile("" ::: "memory");
+  }
+}
+
+static void low_thread(void*) {
+  uart_puts("[sync-lab] L start\n");
+  mutex_lock(&g_lock);
+  uart_puts("[sync-lab] L locked\n");
+
+  // Release H and M.
+  sem_up(&g_start);
+  sem_up(&g_start);
+
+  // Hold the lock until PI is enabled (to create a deterministic inversion window).
+  while (!g_pi_enabled) {
+    spin(20000);
+  }
+
+  uart_puts("[sync-lab] L unlocking\n");
+  mutex_unlock(&g_lock);
+  uart_puts("[sync-lab] L unlocked\n");
+
+  while (1) {
+    asm volatile("wfe");
+  }
+}
+
+static void high_thread(void*) {
+  uart_puts("[sync-lab] H start\n");
+  sem_down(&g_start);
+
+  uart_puts("[sync-lab] H lock...\n");
+  mutex_lock(&g_lock);
+  uart_puts("[sync-lab] H acquired\n");
+  g_high_done = 1;
+  mutex_unlock(&g_lock);
+  uart_puts("[sync-lab] H done\n");
+
+  while (1) {
+    asm volatile("wfe");
+  }
+}
+
+static void medium_thread(void*) {
+  uart_puts("[sync-lab] M start\n");
+  sem_down(&g_start);
+
+  uint64_t t0 = cpu_local()->ticks;
+  bool printed = false;
+  while (!g_high_done) {
+    spin(80000);
+
+    uint64_t dt = cpu_local()->ticks - t0;
+    if (!g_pi_enabled && dt >= 20) {
+      if (!printed) {
+        uart_puts("[sync-lab] inversion observed; enabling PI\n");
+        printed = true;
+      }
+      g_pi_enabled = 1;
+      mutex_set_pi_enabled(&g_lock, 1);
+      thread_yield();
+    }
+  }
+
+  uart_puts("[sync-lab] result PASS\n");
+  while (1) {
+    asm volatile("wfe");
+  }
+}
+}  // namespace
+
+extern "C" void sync_lab_setup(unsigned mode) {
+  (void)mode;
+
+  uart_puts("[sync-lab] setup\n");
+  g_pi_enabled = 0;
+  g_high_done = 0;
+
+  mutex_init(&g_lock);
+  mutex_set_pi_enabled(&g_lock, 0);
+  sem_init(&g_start, 0);
+
+  // Classic 3-thread priority inversion:
+  // - L (low): holds mutex
+  // - H (high): blocks on mutex
+  // - M (medium): runs, starving L until PI boosts L
+  Thread* l = thread_create_prio(low_thread, nullptr, 16 * 1024, /*prio=*/5);
+  Thread* m = thread_create_prio(medium_thread, nullptr, 16 * 1024, /*prio=*/10);
+  Thread* h = thread_create_prio(high_thread, nullptr, 16 * 1024, /*prio=*/20);
+
+  if (!l || !m || !h) {
+    uart_puts("[sync-lab] thread_create failed\n");
+    while (1) {
+      asm volatile("wfe");
+    }
+  }
+
+  sched_add(l);
+  sched_add(m);
+  sched_add(h);
+}
+


### PR DESCRIPTION
Summary: Add an opt-in priority scheduler (SCHED_POLICY=PRIO), blocking mutex/semaphore primitives, and a classic 3-thread priority inversion lab demonstrating priority inheritance (PI), while keeping the default RR/QEMU virt smoke path unchanged.
What changed:
Scheduler: RR/PRIO switch via SCHED_POLICY=RR|PRIO; PRIO selects highest effective_priority and supports rotation among equals.
Sync: sync.h + sync.cc implement non-recursive mutex (PI-capable) and counting semaphore with wait queues.
PI: Threads have base_priority + effective_priority; PI boosts owner based on highest waiter across owned PI-enabled mutexes.
Lab: SYNC_LAB_MODE=1 runs L/M/H inversion scenario and enables PI to recover and print PASS.
Build knobs:
SCHED_POLICY ?= RR
MUTEX_PI ?= 1
SYNC_LAB_MODE ?= 0
How to run:
Default (CI/smoke unchanged): make -j then smoke_run.sh
Priority inversion lab: make -j SCHED_POLICY=PRIO SYNC_LAB_MODE=1 (run under the usual QEMU command)