### PR TITLE
feat(mem): add fixed-size pool, fragmentation lab, and stack guard/watermark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ MUTEX_PI ?= 1
 # Synchronization/scheduler lab mode (default: off).
 SYNC_LAB_MODE ?= 0
 
+# Memory allocator / fragmentation lab mode (default: off).
+MEM_LAB_MODE ?= 0
+
 # Platform selection.
 # - virt: QEMU -machine virt (default, used by CI smoke test)
 # - rpi4: Raspberry Pi 4 (AArch64 firmware-loaded kernel8.img)
@@ -94,6 +97,7 @@ endif
 
 CXXFLAGS += -DMUTEX_PI=$(MUTEX_PI)
 CXXFLAGS += -DSYNC_LAB_MODE=$(SYNC_LAB_MODE)
+CXXFLAGS += -DMEM_LAB_MODE=$(MEM_LAB_MODE)
 
 OBJS := \
   $(OBJ_DIR)/start.o \
@@ -108,6 +112,8 @@ OBJS := \
   $(OBJ_DIR)/timer.o \
   $(OBJ_DIR)/irq.o \
   $(OBJ_DIR)/kmem.o \
+  $(OBJ_DIR)/mem_pool.o \
+  $(OBJ_DIR)/mem_lab.o \
   $(OBJ_DIR)/sync.o \
   $(OBJ_DIR)/thread.o \
   $(OBJ_DIR)/preempt.o \
@@ -159,6 +165,14 @@ $(OBJ_DIR)/irq.o: src/irq.cc include/irq.h
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
 
 $(OBJ_DIR)/kmem.o: src/kmem.cc include/kmem.h
+	mkdir -p $(OBJ_DIR)
+	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
+
+$(OBJ_DIR)/mem_pool.o: src/mem_pool.cc include/mem_pool.h
+	mkdir -p $(OBJ_DIR)
+	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
+
+$(OBJ_DIR)/mem_lab.o: src/mem_lab.cc include/mem_lab.h include/mem_pool.h include/kmem.h
 	mkdir -p $(OBJ_DIR)
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
 

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ OBJS := \
   $(OBJ_DIR)/mmu.o \
   $(OBJ_DIR)/timer.o \
   $(OBJ_DIR)/irq.o \
+  $(OBJ_DIR)/libc.o \
   $(OBJ_DIR)/kmem.o \
   $(OBJ_DIR)/mem_pool.o \
   $(OBJ_DIR)/mem_lab.o \
@@ -161,6 +162,10 @@ $(OBJ_DIR)/timer.o: src/arch/aarch64/timer.cc include/arch/timer.h
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
 
 $(OBJ_DIR)/irq.o: src/irq.cc include/irq.h
+	mkdir -p $(OBJ_DIR)
+	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
+
+$(OBJ_DIR)/libc.o: src/libc.cc
 	mkdir -p $(OBJ_DIR)
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ All knobs are Make variables:
 - `PLATFORM=virt|rpi4` (default: `virt`)
 - `DMA_WINDOW_POLICY=CACHEABLE|NONCACHEABLE` (default: `CACHEABLE`)
 - `DMA_LAB_MODE=0|1|2|...` (default: `0`)
+- `SCHED_POLICY=RR|PRIO` (default: `RR`)
+- `MUTEX_PI=0|1` (default: `1`)
+- `SYNC_LAB_MODE=0|1|...` (default: `0`)
+- `MEM_LAB_MODE=0|1` (default: `0`)
 - `RPI4_UART_CLOCK_HZ=<hz>` (only used when building `PLATFORM=rpi4`)
 
 ## Memory layout
@@ -51,6 +55,8 @@ describe the static memory map:
   window is configurable (cacheable vs non-cacheable) so coherency bugs can be
   reproduced and fixed properly. The 4 KiB alignment matches page granularity,
   simplifying cache maintenance and memory attribute updates.
+
+Additional memory allocator + fragmentation notes: `docs/memory.md`.
 
 ## MMU, caches, and DMA coherency
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,0 +1,88 @@
+# Memory labs: pools, fragmentation, stack vs heap
+
+This repo intentionally runs with MMU + I/D caches enabled early. That makes
+correctness issues (DMA coherency, stack overflow, allocator behavior) show up
+in a realistic way, even on QEMU.
+
+## Why embedded systems often avoid `malloc/free`
+
+General-purpose `malloc/free` is optimized for average-case flexibility, not
+real-time predictability. In firmware, the common issues are:
+
+- **Unpredictable latency**: allocation/free can become O(n) as the free list
+  fragments (scan + split + coalesce).
+- **External fragmentation**: an allocation can fail even when total free memory
+  is large, because no single contiguous block is large enough.
+- **Overhead**: per-allocation metadata + alignment padding consumes RAM.
+- **Harder worst-case reasoning**: long-lived systems accumulate allocator state
+  that is difficult to bound and test exhaustively.
+
+## Fixed-size memory pool (`slab`/freelist style)
+
+For many kernel/driver objects (descriptors, small structs, fixed message
+buffers), a **fixed-size pool** is often a better fit:
+
+- O(1) allocate/free (pop/push a freelist)
+- no external fragmentation
+- predictable failure mode (pool exhausted)
+- easy to instrument
+
+Implementation: `include/mem_pool.h`, `src/mem_pool.cc`.
+
+## Internal vs external fragmentation (demo)
+
+This repo includes a deterministic lab that prints **quantifiable evidence** for
+allocator tradeoffs:
+
+- **Internal fragmentation**: wasted bytes *inside* an allocation because the
+  allocator rounds up (e.g., fixed-size blocks or alignment).
+- **External fragmentation**: free memory exists, but is split into many small
+  holes so a large contiguous allocation fails.
+
+- **Internal fragmentation demo**: allocate variable request sizes out of a
+  fixed-size pool and report wasted bytes.
+- **External fragmentation demo**: a tiny first-fit allocator shows how a large
+  allocation can fail with enough total free memory, and reports the number of
+  search steps (a proxy for latency variability).
+
+Run it by building with `MEM_LAB_MODE=1` (it runs and then halts instead of
+starting the scheduler):
+
+```sh
+make -j MEM_LAB_MODE=1
+make run
+```
+
+Expected log contains sections like:
+
+- `[mem-lab][pool] internal_frag_pct=...`
+- `[mem-lab][malloc] external_frag_pct=...`
+- `[mem-lab][malloc] big alloc FAILED (fragmentation)`
+
+## Stack vs heap in this kernel
+
+This kernel uses several distinct memory regions (see `boot/kernel.ld`):
+
+- **Boot stack**: a fixed 16 KiB stack used only during early boot (`boot/start.S`).
+- **IRQ stack**: a fixed 16 KiB per-CPU stack used by the EL1 IRQ entry stub
+  (`boot/vectors.S`) via `cpu_local()->irq_stack_top`.
+- **Thread stacks**: each kernel thread gets its own stack allocated from the
+  early heap (`thread_create()`).
+- **Heap**: a simple 1 MiB bump allocator (`kmem_alloc_aligned`), suitable for
+  early boot and demos.
+
+## Stack guard + watermark
+
+Thread stacks are initialized with:
+
+- a **guard region** at the bottom of the stack (detects overflow past the base)
+- a **watermark fill pattern** for the remaining unused area (estimates high-water mark)
+
+The scheduler tick path checks the current thread’s guard on every timer tick
+and halts with a diagnostic if it is corrupted.
+
+APIs:
+
+- `thread_stack_guard_ok(t)` returns 1 if the guard is intact.
+- `thread_stack_high_watermark_bytes(t)` returns an estimated maximum stack
+  usage (bytes) since the thread was created.

--- a/include/mem_lab.h
+++ b/include/mem_lab.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Memory allocator lab:
+// - mode=1: run internal vs external fragmentation demos and print metrics
+void mem_lab_run(unsigned mode);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/include/mem_pool.h
+++ b/include/mem_pool.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Fixed-size memory pool backed by a caller-provided region.
+//
+// Goals (embedded-friendly):
+// - O(1) allocation/free (single pointer pop/push)
+// - no external fragmentation
+// - predictable behavior under interrupt/preemption when guarded externally
+//
+// This pool is intentionally simple: it does not do per-block metadata beyond
+// storing the next pointer inside freed blocks.
+struct mem_pool {
+  uint8_t* base;
+  size_t   block_size;
+  size_t   block_count;
+  void*    free_list;   // singly-linked list (pointer stored in freed blocks)
+  size_t   free_count;
+};
+
+// Initialize a pool over [backing, backing+backing_size).
+// Returns 0 on success, -1 on invalid parameters.
+int mem_pool_init(struct mem_pool* pool, void* backing, size_t backing_size, size_t block_size);
+
+// Allocate one block; returns nullptr if exhausted.
+void* mem_pool_alloc(struct mem_pool* pool);
+
+// Free a previously allocated block. Returns 0 on success, -1 on invalid pointer.
+int mem_pool_free(struct mem_pool* pool, void* p);
+
+// Pointer classification helpers.
+int mem_pool_owns(const struct mem_pool* pool, const void* p);
+
+// Stats.
+size_t mem_pool_block_size(const struct mem_pool* pool);
+size_t mem_pool_capacity(const struct mem_pool* pool);
+size_t mem_pool_available(const struct mem_pool* pool);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/include/thread.h
+++ b/include/thread.h
@@ -57,6 +57,12 @@ int  thread_base_priority(const Thread* t);
 int  thread_effective_priority(const Thread* t);
 void thread_set_base_priority(Thread* t, int prio);
 void thread_set_effective_priority(Thread* t, int prio);
+
+// Stack diagnostics for kernel threads.
+// These operate on Thread::stack_base/stack_size and require stack watermark
+// initialization (done by thread_create*) to be meaningful.
+int thread_stack_guard_ok(const Thread* t);
+size_t thread_stack_high_watermark_bytes(const Thread* t);
 #ifdef __cplusplus
 }
 #endif

--- a/src/kmain.cc
+++ b/src/kmain.cc
@@ -11,6 +11,7 @@
 #include "preempt.h"
 #include "dma.h"
 #include "dma_lab.h"
+#include "mem_lab.h"
 #include "sync_lab.h"
 
 extern "C" {
@@ -33,6 +34,10 @@ extern "C" {
 
 #ifndef SYNC_LAB_MODE
 #define SYNC_LAB_MODE 0
+#endif
+
+#ifndef MEM_LAB_MODE
+#define MEM_LAB_MODE 0
 #endif
 
 namespace {
@@ -104,7 +109,7 @@ extern "C" void kmain() {
   uart_puts("[build] "); uart_puts(__DATE__); uart_puts(" "); uart_puts(__TIME__); uart_puts("\n");
 
   uart_puts("[dma-policy] "); uart_puts(DMA_WINDOW_POLICY_STR); uart_puts("\n");
-#if !DMA_LAB_MODE
+#if !DMA_LAB_MODE && !MEM_LAB_MODE
   if (!platform_full_kernel_supported()) {
     uart_puts("[platform] "); uart_puts(platform_name());
     uart_puts(" bring-up: IRQ controller not enabled yet; halting\n");
@@ -115,6 +120,13 @@ extern "C" void kmain() {
   uart_puts("[dma-lab] mode="); uart_print_u64(static_cast<unsigned long long>(DMA_LAB_MODE)); uart_puts("\n");
   dma_lab_run(static_cast<unsigned>(DMA_LAB_MODE));
   uart_puts("[dma-lab] halting\n");
+  while (1) { asm volatile("wfe"); }
+#endif
+
+#if MEM_LAB_MODE
+  uart_puts("[mem-lab] mode="); uart_print_u64(static_cast<unsigned long long>(MEM_LAB_MODE)); uart_puts("\n");
+  mem_lab_run(static_cast<unsigned>(MEM_LAB_MODE));
+  uart_puts("[mem-lab] halting\n");
   while (1) { asm volatile("wfe"); }
 #endif
 

--- a/src/libc.cc
+++ b/src/libc.cc
@@ -1,0 +1,50 @@
+#include <stddef.h>
+#include <stdint.h>
+
+extern "C" void* memset(void* dst, int c, size_t n) {
+  auto* p = static_cast<uint8_t*>(dst);
+  const uint8_t v = static_cast<uint8_t>(c);
+  for (size_t i = 0; i < n; ++i) {
+    p[i] = v;
+  }
+  return dst;
+}
+
+extern "C" void* memcpy(void* dst, const void* src, size_t n) {
+  auto* d = static_cast<uint8_t*>(dst);
+  const auto* s = static_cast<const uint8_t*>(src);
+  for (size_t i = 0; i < n; ++i) {
+    d[i] = s[i];
+  }
+  return dst;
+}
+
+extern "C" void* memmove(void* dst, const void* src, size_t n) {
+  auto* d = static_cast<uint8_t*>(dst);
+  const auto* s = static_cast<const uint8_t*>(src);
+  if (d == s || n == 0) return dst;
+
+  if (d < s) {
+    for (size_t i = 0; i < n; ++i) {
+      d[i] = s[i];
+    }
+    return dst;
+  }
+
+  for (size_t i = n; i != 0; --i) {
+    d[i - 1] = s[i - 1];
+  }
+  return dst;
+}
+
+extern "C" int memcmp(const void* a, const void* b, size_t n) {
+  const auto* p = static_cast<const uint8_t*>(a);
+  const auto* q = static_cast<const uint8_t*>(b);
+  for (size_t i = 0; i < n; ++i) {
+    if (p[i] != q[i]) {
+      return (p[i] < q[i]) ? -1 : 1;
+    }
+  }
+  return 0;
+}
+

--- a/src/mem_lab.cc
+++ b/src/mem_lab.cc
@@ -1,0 +1,294 @@
+#include "mem_lab.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "drivers/uart_pl011.h"
+#include "kmem.h"
+#include "mem_pool.h"
+
+namespace {
+static void put_u64(const char* label, uint64_t v) {
+  uart_puts(label);
+  uart_print_u64(static_cast<unsigned long long>(v));
+  uart_puts("\n");
+}
+
+static inline size_t align_up(size_t v, size_t a) {
+  return (v + a - 1u) & ~(a - 1u);
+}
+
+// ---------- Demo 1: fixed-size pool internal fragmentation ----------
+struct pool_alloc_rec {
+  void*  p;
+  size_t req;
+};
+
+static uint32_t lcg_next(uint32_t* state) {
+  *state = (*state * 1664525u) + 1013904223u;
+  return *state;
+}
+
+static void demo_pool_internal_fragmentation() {
+  uart_puts("[mem-lab][pool] internal fragmentation demo\n");
+
+  constexpr size_t kBackingBytes = 64 * 1024;
+  constexpr size_t kBlockSize = 256;
+  constexpr size_t kMaxAllocs = 128;
+
+  void* backing = kmem_alloc_aligned(kBackingBytes, 64);
+  if (!backing) {
+    uart_puts("[mem-lab][pool] backing alloc failed\n");
+    return;
+  }
+
+  mem_pool pool;
+  if (mem_pool_init(&pool, backing, kBackingBytes, kBlockSize) != 0) {
+    uart_puts("[mem-lab][pool] mem_pool_init failed\n");
+    return;
+  }
+
+  pool_alloc_rec recs[kMaxAllocs] = {};
+  uint32_t rng = 0x12345678u;
+
+  size_t allocs = 0;
+  size_t wasted = 0;
+  size_t provided = 0;
+
+  for (size_t i = 0; i < kMaxAllocs; ++i) {
+    const size_t req = 1u + (lcg_next(&rng) % kBlockSize);
+    void* p = mem_pool_alloc(&pool);
+    if (!p) break;
+    recs[i] = {p, req};
+    allocs++;
+    provided += mem_pool_block_size(&pool);
+    wasted += (mem_pool_block_size(&pool) - req);
+  }
+
+  put_u64("[mem-lab][pool] allocs=", allocs);
+  put_u64("[mem-lab][pool] block_size=", mem_pool_block_size(&pool));
+  put_u64("[mem-lab][pool] provided_bytes=", provided);
+  put_u64("[mem-lab][pool] requested_bytes=", (provided - wasted));
+  put_u64("[mem-lab][pool] wasted_bytes=", wasted);
+  if (provided) {
+    const uint64_t pct = (static_cast<uint64_t>(wasted) * 100u) / static_cast<uint64_t>(provided);
+    put_u64("[mem-lab][pool] internal_frag_pct=", pct);
+  }
+
+  // Free everything (should be O(1) per op).
+  for (size_t i = 0; i < allocs; ++i) {
+    if (recs[i].p) {
+      mem_pool_free(&pool, recs[i].p);
+    }
+  }
+  put_u64("[mem-lab][pool] free_count=", mem_pool_available(&pool));
+}
+
+// ---------- Demo 2: "malloc" external fragmentation + variable cost ----------
+//
+// This is a deliberately tiny first-fit allocator used only for demonstration.
+// It is not wired into the kernel allocator path.
+struct heap_block {
+  uint32_t magic;
+  uint32_t flags;  // bit0 = free
+  size_t   size;   // payload bytes
+};
+
+constexpr uint32_t kHeapMagic = 0x6d656d31u;  // "mem1"
+constexpr uint32_t kHeapFree = 1u;
+
+static heap_block* heap_next(heap_block* b) {
+  uint8_t* p = reinterpret_cast<uint8_t*>(b);
+  p += sizeof(heap_block);
+  p += b->size;
+  p = reinterpret_cast<uint8_t*>(align_up(reinterpret_cast<size_t>(p), 16));
+  return reinterpret_cast<heap_block*>(p);
+}
+
+static void heap_init(void* mem, size_t bytes) {
+  auto* b = reinterpret_cast<heap_block*>(mem);
+  b->magic = kHeapMagic;
+  b->flags = kHeapFree;
+  b->size = bytes - sizeof(heap_block);
+}
+
+static void* heap_alloc_first_fit(void* heap, size_t heap_bytes, size_t req, size_t* out_steps) {
+  if (!heap || req == 0) return nullptr;
+  req = align_up(req, 16);
+
+  uint8_t* base = reinterpret_cast<uint8_t*>(heap);
+  uint8_t* end = base + heap_bytes;
+  size_t steps = 0;
+
+  for (heap_block* b = reinterpret_cast<heap_block*>(base);
+       reinterpret_cast<uint8_t*>(b) + sizeof(heap_block) <= end;
+       b = heap_next(b)) {
+    if (b->magic != kHeapMagic) break;
+    steps++;
+    if ((b->flags & kHeapFree) == 0) continue;
+    if (b->size < req) continue;
+
+    // Split if there is room for a new header and a small payload.
+    uint8_t* payload = reinterpret_cast<uint8_t*>(b) + sizeof(heap_block);
+    uint8_t* old_end = reinterpret_cast<uint8_t*>(align_up(reinterpret_cast<size_t>(payload + b->size), 16));
+    uint8_t* new_hdr = reinterpret_cast<uint8_t*>(align_up(reinterpret_cast<size_t>(payload + req), 16));
+    uint8_t* new_payload = new_hdr + sizeof(heap_block);
+    if (new_payload + 16u <= old_end) {
+      auto* nb = reinterpret_cast<heap_block*>(new_hdr);
+      nb->magic = kHeapMagic;
+      nb->flags = kHeapFree;
+      nb->size = static_cast<size_t>(old_end - new_payload);
+      b->size = req;
+    }
+
+    b->flags &= ~kHeapFree;
+    if (out_steps) *out_steps = steps;
+    return reinterpret_cast<uint8_t*>(b) + sizeof(heap_block);
+  }
+
+  if (out_steps) *out_steps = steps;
+  return nullptr;
+}
+
+static void heap_coalesce(void* heap, size_t heap_bytes) {
+  uint8_t* base = reinterpret_cast<uint8_t*>(heap);
+  uint8_t* end = base + heap_bytes;
+
+  for (heap_block* b = reinterpret_cast<heap_block*>(base);
+       reinterpret_cast<uint8_t*>(b) + sizeof(heap_block) <= end;) {
+    if (b->magic != kHeapMagic) break;
+    heap_block* n = heap_next(b);
+    if (reinterpret_cast<uint8_t*>(n) + sizeof(heap_block) > end) break;
+    if (n->magic != kHeapMagic) break;
+
+    if ((b->flags & kHeapFree) && (n->flags & kHeapFree)) {
+      // Merge n into b.
+      uint8_t* b_payload = reinterpret_cast<uint8_t*>(b) + sizeof(heap_block);
+      uint8_t* n_payload = reinterpret_cast<uint8_t*>(n) + sizeof(heap_block);
+      const size_t gap = static_cast<size_t>(n_payload - (b_payload + b->size));
+      b->size = b->size + gap + n->size;
+      continue;
+    }
+    b = n;
+  }
+}
+
+static void heap_free(void* heap, size_t heap_bytes, void* p) {
+  if (!heap || !p) return;
+  uint8_t* base = reinterpret_cast<uint8_t*>(heap);
+  uint8_t* end = base + heap_bytes;
+  uint8_t* v = reinterpret_cast<uint8_t*>(p);
+  if (v < base + sizeof(heap_block) || v >= end) return;
+
+  auto* b = reinterpret_cast<heap_block*>(v - sizeof(heap_block));
+  if (b->magic != kHeapMagic) return;
+  b->flags |= kHeapFree;
+  heap_coalesce(heap, heap_bytes);
+}
+
+static void heap_stats(void* heap, size_t heap_bytes, size_t* total_free, size_t* largest_free, size_t* free_blocks) {
+  if (total_free) *total_free = 0;
+  if (largest_free) *largest_free = 0;
+  if (free_blocks) *free_blocks = 0;
+
+  uint8_t* base = reinterpret_cast<uint8_t*>(heap);
+  uint8_t* end = base + heap_bytes;
+  for (heap_block* b = reinterpret_cast<heap_block*>(base);
+       reinterpret_cast<uint8_t*>(b) + sizeof(heap_block) <= end;
+       b = heap_next(b)) {
+    if (b->magic != kHeapMagic) break;
+    if ((b->flags & kHeapFree) == 0) continue;
+    if (total_free) *total_free += b->size;
+    if (largest_free && b->size > *largest_free) *largest_free = b->size;
+    if (free_blocks) (*free_blocks)++;
+  }
+}
+
+static void demo_malloc_external_fragmentation() {
+  uart_puts("[mem-lab][malloc] external fragmentation demo\n");
+
+  constexpr size_t kHeapBytes = 64 * 1024;
+  void* heap = kmem_alloc_aligned(kHeapBytes, 16);
+  if (!heap) {
+    uart_puts("[mem-lab][malloc] heap alloc failed\n");
+    return;
+  }
+
+  heap_init(heap, kHeapBytes);
+  put_u64("[mem-lab][malloc] heap_bytes=", kHeapBytes);
+  put_u64("[mem-lab][malloc] header_bytes=", sizeof(heap_block));
+
+  // Allocate many medium chunks, then free every other chunk.
+  constexpr size_t kChunk = 1024;
+  constexpr size_t kMax = 32;
+  void* ptrs[kMax] = {};
+
+  size_t steps_total = 0;
+  size_t steps_max = 0;
+  size_t allocs = 0;
+
+  for (size_t i = 0; i < kMax; ++i) {
+    size_t steps = 0;
+    void* p = heap_alloc_first_fit(heap, kHeapBytes, kChunk, &steps);
+    if (!p) break;
+    ptrs[i] = p;
+    allocs++;
+    steps_total += steps;
+    if (steps > steps_max) steps_max = steps;
+  }
+  put_u64("[mem-lab][malloc] allocs=", allocs);
+  put_u64("[mem-lab][malloc] alloc_steps_avg=", allocs ? (steps_total / allocs) : 0);
+  put_u64("[mem-lab][malloc] alloc_steps_max=", steps_max);
+
+  for (size_t i = 0; i < allocs; i += 2) {
+    heap_free(heap, kHeapBytes, ptrs[i]);
+    ptrs[i] = nullptr;
+  }
+
+  size_t total_free = 0, largest_free = 0, free_blocks = 0;
+  heap_stats(heap, kHeapBytes, &total_free, &largest_free, &free_blocks);
+
+  put_u64("[mem-lab][malloc] free_blocks=", free_blocks);
+  put_u64("[mem-lab][malloc] total_free=", total_free);
+  put_u64("[mem-lab][malloc] largest_free=", largest_free);
+  if (total_free) {
+    const uint64_t frag_pct = (total_free > largest_free)
+                                  ? ((static_cast<uint64_t>(total_free - largest_free) * 100u) / static_cast<uint64_t>(total_free))
+                                  : 0u;
+    put_u64("[mem-lab][malloc] external_frag_pct=", frag_pct);
+  }
+
+  // Demonstrate a classic external fragmentation failure: enough total free,
+  // but no sufficiently large contiguous chunk.
+  constexpr size_t kBig = 8 * 1024;
+  if (total_free > kBig && largest_free < kBig) {
+    uart_puts("[mem-lab][malloc] expected: total_free > big && largest_free < big\n");
+  }
+  size_t steps = 0;
+  void* big = heap_alloc_first_fit(heap, kHeapBytes, kBig, &steps);
+  if (!big) {
+    uart_puts("[mem-lab][malloc] big alloc FAILED (fragmentation)\n");
+  } else {
+    uart_puts("[mem-lab][malloc] big alloc unexpectedly succeeded\n");
+  }
+  put_u64("[mem-lab][malloc] big_alloc_steps=", steps);
+}
+
+static void print_embedded_malloc_takeaways() {
+  uart_puts("[mem-lab] why embedded often avoids malloc/free:\n");
+  uart_puts("  - unpredictable latency (first-fit search/coalesce steps vary)\n");
+  uart_puts("  - external fragmentation (alloc can fail with memory still free)\n");
+  uart_puts("  - metadata + alignment overhead (headers consume RAM)\n");
+  uart_puts("  - harder to reason about worst-case behavior under load\n");
+}
+}  // namespace
+
+extern "C" void mem_lab_run(unsigned mode) {
+  if (mode == 0) return;
+
+  uart_puts("[mem-lab] begin\n");
+  demo_pool_internal_fragmentation();
+  demo_malloc_external_fragmentation();
+  print_embedded_malloc_takeaways();
+  uart_puts("[mem-lab] end\n");
+}

--- a/src/mem_pool.cc
+++ b/src/mem_pool.cc
@@ -91,6 +91,7 @@ extern "C" void* mem_pool_alloc(struct mem_pool* pool) {
 extern "C" int mem_pool_free(struct mem_pool* pool, void* p) {
   if (!pool || !p) return -1;
   if (!mem_pool_owns(pool, p)) return -1;
+  if (pool->free_count >= pool->block_count) return -1;
 
 #if MEM_POOL_DEBUG
   if (freelist_contains(pool->free_list, p)) {
@@ -125,4 +126,3 @@ extern "C" size_t mem_pool_capacity(const struct mem_pool* pool) {
 extern "C" size_t mem_pool_available(const struct mem_pool* pool) {
   return pool ? pool->free_count : 0;
 }
-

--- a/src/mem_pool.cc
+++ b/src/mem_pool.cc
@@ -1,0 +1,128 @@
+#include "mem_pool.h"
+
+#include <stdint.h>
+
+namespace {
+#ifndef MEM_POOL_DEBUG
+#define MEM_POOL_DEBUG 0
+#endif
+
+static inline uintptr_t align_up(uintptr_t v, uintptr_t a) {
+  return (v + a - 1u) & ~(a - 1u);
+}
+
+static inline bool is_pow2(uintptr_t v) {
+  return v && ((v & (v - 1u)) == 0u);
+}
+
+static inline size_t clamp_align(size_t a) {
+  if (a < alignof(void*)) return alignof(void*);
+  if (!is_pow2(a)) {
+    size_t x = 1u;
+    while (x < a) x <<= 1u;
+    return x;
+  }
+  return a;
+}
+
+static inline void* load_next(void* p) {
+  return *reinterpret_cast<void**>(p);
+}
+
+static inline void store_next(void* p, void* next) {
+  *reinterpret_cast<void**>(p) = next;
+}
+
+#if MEM_POOL_DEBUG
+static bool freelist_contains(void* head, const void* p) {
+  for (void* it = head; it; it = load_next(it)) {
+    if (it == p) return true;
+  }
+  return false;
+}
+#endif
+}  // namespace
+
+extern "C" int mem_pool_init(struct mem_pool* pool, void* backing, size_t backing_size, size_t block_size) {
+  if (!pool || !backing || backing_size == 0 || block_size == 0) {
+    return -1;
+  }
+  if (block_size < sizeof(void*)) {
+    return -1;
+  }
+
+  const size_t align = clamp_align(16);
+  const uintptr_t raw = reinterpret_cast<uintptr_t>(backing);
+  const uintptr_t aligned = align_up(raw, align);
+  if (aligned < raw) return -1;
+  const size_t lost = static_cast<size_t>(aligned - raw);
+  if (lost >= backing_size) return -1;
+  size_t usable = backing_size - lost;
+
+  const size_t blk = static_cast<size_t>(align_up(block_size, align));
+  if (blk == 0) return -1;
+  const size_t count = usable / blk;
+  if (count == 0) return -1;
+
+  pool->base = reinterpret_cast<uint8_t*>(aligned);
+  pool->block_size = blk;
+  pool->block_count = count;
+  pool->free_count = count;
+
+  void* head = nullptr;
+  for (size_t i = 0; i < count; ++i) {
+    void* b = pool->base + i * blk;
+    store_next(b, head);
+    head = b;
+  }
+  pool->free_list = head;
+  return 0;
+}
+
+extern "C" void* mem_pool_alloc(struct mem_pool* pool) {
+  if (!pool || !pool->free_list) return nullptr;
+  void* p = pool->free_list;
+  pool->free_list = load_next(p);
+  if (pool->free_count) pool->free_count--;
+  store_next(p, nullptr);
+  return p;
+}
+
+extern "C" int mem_pool_free(struct mem_pool* pool, void* p) {
+  if (!pool || !p) return -1;
+  if (!mem_pool_owns(pool, p)) return -1;
+
+#if MEM_POOL_DEBUG
+  if (freelist_contains(pool->free_list, p)) {
+    return -1;
+  }
+#endif
+
+  store_next(p, pool->free_list);
+  pool->free_list = p;
+  pool->free_count++;
+  return 0;
+}
+
+extern "C" int mem_pool_owns(const struct mem_pool* pool, const void* p) {
+  if (!pool || !pool->base || !p) return 0;
+  const uintptr_t start = reinterpret_cast<uintptr_t>(pool->base);
+  const uintptr_t end = start + pool->block_count * pool->block_size;
+  const uintptr_t v = reinterpret_cast<uintptr_t>(p);
+  if (v < start || v >= end) return 0;
+  const uintptr_t off = v - start;
+  return (off % pool->block_size) == 0u;
+}
+
+extern "C" size_t mem_pool_block_size(const struct mem_pool* pool) {
+  return pool ? pool->block_size : 0;
+}
+
+extern "C" size_t mem_pool_capacity(const struct mem_pool* pool) {
+  return pool ? pool->block_count : 0;
+}
+
+extern "C" size_t mem_pool_available(const struct mem_pool* pool) {
+  return pool ? pool->free_count : 0;
+}
+


### PR DESCRIPTION
- Add mem_pool freelist allocator (mem_pool.h (line 1), mem_pool.cc (line 1)) plus MEM_LAB_MODE fragmentation demos (mem_lab.h (line 1), mem_lab.cc (line 1)) and docs (memory.md (line 1)).
- Add thread stack guard + watermark instrumentation (thread.cc (line 1), thread.h (line 1)).
- Fix freestanding link by providing minimal memset/memcpy/memmove/memcmp (libc.cc (line 1)) and linking it (Makefile (line 1)).
- Default CI/smoke path unchanged (MEM_LAB_MODE defaults to 0; lab runs only when enabled in kmain.cc (line 1)).