### PR TITLE
Labs: deadlock modes + stack guard pages; use mem_pool for Thread

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ SYNC_LAB_MODE ?= 0
 # Memory allocator / fragmentation lab mode (default: off).
 MEM_LAB_MODE ?= 0
 
+# Stack guard-page lab mode (default: off).
+STACK_LAB_MODE ?= 0
+
 # Platform selection.
 # - virt: QEMU -machine virt (default, used by CI smoke test)
 # - rpi4: Raspberry Pi 4 (AArch64 firmware-loaded kernel8.img)
@@ -98,6 +101,7 @@ endif
 CXXFLAGS += -DMUTEX_PI=$(MUTEX_PI)
 CXXFLAGS += -DSYNC_LAB_MODE=$(SYNC_LAB_MODE)
 CXXFLAGS += -DMEM_LAB_MODE=$(MEM_LAB_MODE)
+CXXFLAGS += -DSTACK_LAB_MODE=$(STACK_LAB_MODE)
 
 OBJS := \
   $(OBJ_DIR)/start.o \
@@ -121,6 +125,7 @@ OBJS := \
   $(OBJ_DIR)/dma.o \
   $(OBJ_DIR)/dma_lab.o \
   $(OBJ_DIR)/sync_lab.o \
+  $(OBJ_DIR)/stack_lab.o \
   $(OBJ_DIR)/except.o \
   $(OBJ_DIR)/fpsimd.o \
   $(OBJ_DIR)/kmain.o
@@ -202,6 +207,10 @@ $(OBJ_DIR)/dma_lab.o: src/dma_lab.cc include/dma_lab.h include/dma.h include/kme
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
 
 $(OBJ_DIR)/sync_lab.o: src/sync_lab.cc include/sync_lab.h include/sync.h include/thread.h
+	mkdir -p $(OBJ_DIR)
+	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
+
+$(OBJ_DIR)/stack_lab.o: src/stack_lab.cc include/stack_lab.h include/thread.h include/arch/cpu_local.h
 	mkdir -p $(OBJ_DIR)
 	$(CXX) $(CXXFLAGS) -Iinclude -Isrc -c $< -o $@
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ All knobs are Make variables:
 - `MUTEX_PI=0|1` (default: `1`)
 - `SYNC_LAB_MODE=0|1|...` (default: `0`)
 - `MEM_LAB_MODE=0|1` (default: `0`)
+- `STACK_LAB_MODE=0|1` (default: `0`)
 - `RPI4_UART_CLOCK_HZ=<hz>` (only used when building `PLATFORM=rpi4`)
 
 ## Memory layout
@@ -97,6 +98,37 @@ Examples:
 
 - Run the full suite: `DMA_LAB_MODE=1 DMA_WINDOW_POLICY=CACHEABLE scripts/dma_lab_run.sh`
 - Run a single case (best-effort): `DMA_LAB_MODE=3 DMA_WINDOW_POLICY=CACHEABLE scripts/dma_lab_run.sh`
+
+### Memory lab mode
+
+`MEM_LAB_MODE=1` runs deterministic fragmentation demos and then halts. Run it with:
+
+- `MEM_LAB_MODE=1 scripts/mem_lab_run.sh`
+
+Expected log contains:
+
+- `[mem-lab][pool] internal_frag_pct=...`
+- `[mem-lab][malloc] external_frag_pct=...`
+- `[mem-lab][malloc] big alloc FAILED (fragmentation)`
+
+### Sync + scheduling labs
+
+Run the priority inversion + PI lab:
+
+- `SCHED_POLICY=PRIO SYNC_LAB_MODE=1 scripts/sync_lab_run.sh`
+
+Run the deadlock lab variants (2 locks / 2 threads):
+
+- Deadlock reproduction: `SCHED_POLICY=PRIO SYNC_LAB_MODE=2 scripts/sync_lab_run.sh`
+- Lock ordering fix: `SCHED_POLICY=PRIO SYNC_LAB_MODE=3 scripts/sync_lab_run.sh`
+- Trylock+backoff fix: `SCHED_POLICY=PRIO SYNC_LAB_MODE=4 scripts/sync_lab_run.sh`
+- Lockdep detection: `SCHED_POLICY=PRIO SYNC_LAB_MODE=5 scripts/sync_lab_run.sh`
+
+### Stack lab mode
+
+`STACK_LAB_MODE=1` intentionally touches a guard page below a thread stack and is expected to fault:
+
+- `STACK_LAB_MODE=1 scripts/stack_lab_run.sh`
 
 ## Design case studies (STAR)
 

--- a/include/arch/mmu.h
+++ b/include/arch/mmu.h
@@ -8,3 +8,10 @@ void mmu_init(bool enable);
 
 // Dump key EL1 system registers to the UART for diagnostics.
 void mmu_dump_state();
+
+// Return 1 if EL1 stage-1 translation is enabled.
+int mmu_enabled(void);
+
+// Mark the 4 KiB page containing |addr| as invalid (guard page).
+// Returns 0 on success, -1 on unsupported address/state.
+int mmu_guard_page(void* addr);

--- a/include/stack_lab.h
+++ b/include/stack_lab.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Stack lab:
+// - mode=1: probe guard page (expected synchronous exception on access)
+void stack_lab_setup(unsigned mode);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/include/sync.h
+++ b/include/sync.h
@@ -17,6 +17,9 @@ struct mutex {
 void mutex_init(mutex* m);
 void mutex_set_pi_enabled(mutex* m, int enabled);
 void mutex_lock(mutex* m);
+// Try to acquire a mutex without blocking.
+// Returns 0 on success, -1 if the mutex is currently owned by another thread.
+int  mutex_trylock(mutex* m);
 void mutex_unlock(mutex* m);
 
 // Counting semaphore.
@@ -32,4 +35,3 @@ void sem_up(semaphore* s);
 #ifdef __cplusplus
 }
 #endif
-

--- a/include/sync_lab.h
+++ b/include/sync_lab.h
@@ -5,10 +5,14 @@ extern "C" {
 #endif
 
 // Priority inversion lab:
-// - mode=1: demonstrate inversion, then enable PI and recover (expected PASS)
+// - mode=1: classic 3-thread inversion; enable PI and recover (expected PASS)
+// Deadlock lab (2 locks / 2 threads + watchdog):
+// - mode=2: intentionally deadlock (AB/BA) and detect it
+// - mode=3: avoid deadlock via global lock ordering
+// - mode=4: avoid deadlock via trylock + backoff
+// - mode=5: avoid deadlock via simplified lockdep (cycle detection)
 void sync_lab_setup(unsigned mode);
 
 #ifdef __cplusplus
 }
 #endif
-

--- a/include/thread.h
+++ b/include/thread.h
@@ -19,6 +19,7 @@ struct Thread {
   int        effective_priority;  // may be boosted by priority inheritance
   int        state;               // 0=READY, 1=BLOCKED
   Thread*    wait_next;           // used by wait-queues (mutex/semaphore)
+  mutex*     waiting_on;          // mutex this thread is blocked on (for lockdep)
   mutex*     owned_mutexes;       // list head for priority inheritance
 
   // ---- FPSIMD context ----

--- a/scripts/smoke_run.sh
+++ b/scripts/smoke_run.sh
@@ -16,7 +16,14 @@ TRACE_LOG="${BUILD_DIR}/qemu-trace.log"
 
 echo "[smoke] Building kernel (make clean && make -j)..."
 make clean
-if ! make -j; then
+SMOKE_MAKE_ARGS=(
+  DMA_LAB_MODE=0
+  MEM_LAB_MODE=0
+  SYNC_LAB_MODE=0
+  STACK_LAB_MODE=0
+  SCHED_POLICY=RR
+)
+if ! make -j "${SMOKE_MAKE_ARGS[@]}"; then
   echo "::error ::Kernel build failed; see make output above"
   exit 1
 fi

--- a/scripts/stack_lab_run.sh
+++ b/scripts/stack_lab_run.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v qemu-system-aarch64 >/dev/null 2>&1; then
+  echo "::error ::qemu-system-aarch64 not found in PATH; install QEMU to run stack lab"
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+BUILD_DIR="${REPO_ROOT}/build"
+LOG_PATH="${BUILD_DIR}/qemu-stack-lab.log"
+TRACE_LOG="${BUILD_DIR}/qemu-stack-lab-trace.log"
+
+STACK_LAB_MODE="${STACK_LAB_MODE:-1}"
+
+echo "[stack-lab] Building kernel (STACK_LAB_MODE=${STACK_LAB_MODE})..."
+make clean
+if ! make -j \
+  DMA_LAB_MODE=0 \
+  MEM_LAB_MODE=0 \
+  SYNC_LAB_MODE=0 \
+  SCHED_POLICY=RR \
+  STACK_LAB_MODE="${STACK_LAB_MODE}"; then
+  echo "::error ::Kernel build failed; see make output above"
+  exit 1
+fi
+
+mkdir -p "${BUILD_DIR}"
+
+: >"${LOG_PATH}"
+: >"${TRACE_LOG}"
+
+CMD=(
+  qemu-system-aarch64
+  -machine virt,gic-version=3
+  -cpu cortex-a72
+  -smp 1
+  -m 512
+  -nographic
+  -serial mon:stdio
+  -kernel "${BUILD_DIR}/kernel.elf"
+  -d guest_errors,unimp
+  -D "${TRACE_LOG}"
+)
+
+echo "[stack-lab] Launching QEMU with 6s timeout..."
+set +e
+timeout 6s "${CMD[@]}" 2>&1 | tee "${LOG_PATH}"
+status=${PIPESTATUS[0]}
+set -e
+
+if [[ ${status} -eq 124 ]]; then
+  echo "[stack-lab] QEMU terminated after timeout (expected for faulting lab)."
+  status=0
+fi
+if [[ ${status} -ne 0 ]]; then
+  echo "[stack-lab] QEMU exited with status ${status}."
+  exit "${status}"
+fi
+
+if [[ -s "${TRACE_LOG}" ]] && grep -Eq '(^unimp([[:space:]:]|$)|unimp:|unimplemented|guest[_[:space:]]+error|guest_errors)' "${TRACE_LOG}"; then
+  echo "::error ::QEMU produced guest_errors/unimp logs (see ${TRACE_LOG})"
+  tail -n 50 "${TRACE_LOG}" || true
+  exit 1
+fi
+
+if ! grep -qF "[stack-lab] writing guard page" "${LOG_PATH}"; then
+  echo "::error ::Missing stack lab marker; see ${LOG_PATH}"
+  tail -n 120 "${LOG_PATH}" || true
+  exit 1
+fi
+
+if ! grep -qF "[EXC]" "${LOG_PATH}"; then
+  echo "::error ::Expected a synchronous exception from guard page access, but none was seen"
+  tail -n 120 "${LOG_PATH}" || true
+  exit 1
+fi
+
+if ! grep -qF "(DABT)" "${LOG_PATH}"; then
+  echo "::error ::Expected a DABT exception for guard page access"
+  tail -n 120 "${LOG_PATH}" || true
+  exit 1
+fi
+
+echo "[stack-lab] All lab checks passed."

--- a/scripts/sync_lab_run.sh
+++ b/scripts/sync_lab_run.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v qemu-system-aarch64 >/dev/null 2>&1; then
+  echo "::error ::qemu-system-aarch64 not found in PATH; install QEMU to run sync labs"
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+BUILD_DIR="${REPO_ROOT}/build"
+LOG_PATH="${BUILD_DIR}/qemu-sync-lab.log"
+TRACE_LOG="${BUILD_DIR}/qemu-sync-lab-trace.log"
+
+SYNC_LAB_MODE="${SYNC_LAB_MODE:-1}"
+
+echo "[sync-lab] Building kernel (SCHED_POLICY=PRIO SYNC_LAB_MODE=${SYNC_LAB_MODE})..."
+make clean
+if ! make -j \
+  DMA_LAB_MODE=0 \
+  MEM_LAB_MODE=0 \
+  STACK_LAB_MODE=0 \
+  SCHED_POLICY=PRIO \
+  SYNC_LAB_MODE="${SYNC_LAB_MODE}"; then
+  echo "::error ::Kernel build failed; see make output above"
+  exit 1
+fi
+
+mkdir -p "${BUILD_DIR}"
+
+: >"${LOG_PATH}"
+: >"${TRACE_LOG}"
+
+CMD=(
+  qemu-system-aarch64
+  -machine virt,gic-version=3
+  -cpu cortex-a72
+  -smp 1
+  -m 512
+  -nographic
+  -serial mon:stdio
+  -kernel "${BUILD_DIR}/kernel.elf"
+  -d guest_errors,unimp
+  -D "${TRACE_LOG}"
+)
+
+echo "[sync-lab] Launching QEMU with 10s timeout..."
+set +e
+timeout 10s "${CMD[@]}" 2>&1 | tee "${LOG_PATH}"
+status=${PIPESTATUS[0]}
+set -e
+
+if [[ ${status} -eq 124 ]]; then
+  echo "[sync-lab] QEMU terminated after timeout (expected for lab)."
+  status=0
+fi
+if [[ ${status} -ne 0 ]]; then
+  echo "[sync-lab] QEMU exited with status ${status}."
+  exit "${status}"
+fi
+
+if [[ -s "${TRACE_LOG}" ]] && grep -Eq '(^unimp([[:space:]:]|$)|unimp:|unimplemented|guest[_[:space:]]+error|guest_errors)' "${TRACE_LOG}"; then
+  echo "::error ::QEMU produced guest_errors/unimp logs (see ${TRACE_LOG})"
+  tail -n 50 "${TRACE_LOG}" || true
+  exit 1
+fi
+
+if grep -qF "[EXC]" "${LOG_PATH}"; then
+  echo "::error ::Unexpected exception in sync lab log; see ${LOG_PATH}"
+  exit 1
+fi
+
+case "${SYNC_LAB_MODE}" in
+  1)
+    required=("inversion observed; enabling PI" "result PASS")
+    ;;
+  2)
+    required=("[deadlock-lab] deadlock observed")
+    ;;
+  3|4)
+    required=("[deadlock-lab] result PASS")
+    ;;
+  5)
+    required=("[lockdep] result PASS")
+    ;;
+  *)
+    echo "::error ::Unknown SYNC_LAB_MODE=${SYNC_LAB_MODE} for script expectations"
+    exit 2
+    ;;
+esac
+
+for needle in "${required[@]}"; do
+  if ! grep -qF "${needle}" "${LOG_PATH}"; then
+    echo "::error ::Missing expected sync lab output: ${needle}"
+    tail -n 160 "${LOG_PATH}" || true
+    exit 1
+  fi
+done
+
+echo "[sync-lab] All lab checks passed."

--- a/src/arch/aarch64/mmu.cc
+++ b/src/arch/aarch64/mmu.cc
@@ -34,6 +34,9 @@ static inline void write_sctlr_el1(uint64_t v){ asm volatile("msr sctlr_el1, %0"
 static inline void tlbi_vmalle1() { asm volatile("tlbi vmalle1"); }
 static inline void ic_iallu() { asm volatile("ic iallu"); }
 
+constexpr uint64_t kPtePxN = 1ull << 53;
+constexpr uint64_t kPteUxN = 1ull << 54;
+
 constexpr uint64_t kAttrIdxNormal = 0;
 constexpr uint64_t kAttrIdxDevice = 1;
 constexpr uint64_t kAttrIdxNormalNc = 2;
@@ -96,6 +99,8 @@ alignas(4096) static uint64_t g_l1[512];
 alignas(4096) static uint64_t g_l2_ram[512];
 alignas(4096) static uint64_t g_l3_dma0[512];
 alignas(4096) static uint64_t g_l3_dma1[512];
+alignas(4096) static uint64_t g_l3_extra[8][512];
+static unsigned g_l3_extra_next = 0;
 
 extern "C" {
 extern char __dma_nc_start[];
@@ -122,9 +127,12 @@ static void build_identity_map() {
     g_l3_dma0[i] = 0;
     g_l3_dma1[i] = 0;
   }
-
-  constexpr uint64_t kPtePxN = 1ull << 53;
-  constexpr uint64_t kPteUxN = 1ull << 54;
+  for (unsigned t = 0; t < (sizeof(g_l3_extra) / sizeof(g_l3_extra[0])); ++t) {
+    for (unsigned i = 0; i < 512; ++i) {
+      g_l3_extra[t][i] = 0;
+    }
+  }
+  g_l3_extra_next = 0;
 
   g_l0[0] = pte_table(static_cast<uint64_t>(reinterpret_cast<uintptr_t>(g_l1)));
 
@@ -178,6 +186,40 @@ static void build_identity_map() {
   }
 
   dsb_ish();
+}
+
+static inline uintptr_t align_down(uintptr_t v, uintptr_t a) {
+  return v & ~(a - 1u);
+}
+
+static uint64_t* ensure_l3_for_ram_block(unsigned l2_index) {
+  if (l2_index >= 512) return nullptr;
+  uint64_t e = g_l2_ram[l2_index];
+  const uint64_t type = e & 0b11ull;
+
+  if (type == 0b11ull) {
+    uintptr_t table_phys = static_cast<uintptr_t>(e & 0x0000FFFFFFFFF000ull);
+    return reinterpret_cast<uint64_t*>(table_phys);
+  }
+  if (type != 0b01ull) {
+    return nullptr;
+  }
+  if (g_l3_extra_next >= (sizeof(g_l3_extra) / sizeof(g_l3_extra[0]))) {
+    return nullptr;
+  }
+
+  uint64_t* l3 = g_l3_extra[g_l3_extra_next++];
+  const uint64_t attr_index = (e >> 2) & 0x7ull;
+  const uint64_t sh = (e >> 8) & 0x3ull;
+  const uint64_t xn = e & (kPtePxN | kPteUxN);
+
+  const uintptr_t block_base = kRamBase + (static_cast<uintptr_t>(l2_index) * kL2BlockSize);
+  for (unsigned i = 0; i < 512; ++i) {
+    uintptr_t va = block_base + (static_cast<uintptr_t>(i) * kPageSize);
+    l3[i] = pte_page(static_cast<uint64_t>(va), attr_index, sh) | xn;
+  }
+  g_l2_ram[l2_index] = pte_table(static_cast<uint64_t>(reinterpret_cast<uintptr_t>(l3)));
+  return l3;
 }
 }  // namespace
 
@@ -233,4 +275,31 @@ void mmu_init(bool enable) {
   sctlr |= (1ull << 12);  // I: instruction cache enable
   write_sctlr_el1(sctlr);
   isb();
+}
+
+int mmu_enabled(void) {
+  return (read_sctlr_el1() & 1u) != 0;
+}
+
+int mmu_guard_page(void* addr) {
+  if (!addr) return -1;
+  if (!mmu_enabled()) return -1;
+
+  uintptr_t va = align_down(reinterpret_cast<uintptr_t>(addr), kPageSize);
+  if (va < kRamBase || va >= kRamLimit) return -1;
+
+  const uintptr_t off = va - kRamBase;
+  const unsigned l2_index = static_cast<unsigned>(off / kL2BlockSize);
+  const unsigned l3_index = static_cast<unsigned>((off % kL2BlockSize) / kPageSize);
+
+  uint64_t* l3 = ensure_l3_for_ram_block(l2_index);
+  if (!l3) return -1;
+
+  l3[l3_index] = 0;  // invalid descriptor => translation fault
+
+  dsb_ish();
+  tlbi_vmalle1();
+  dsb_ish();
+  isb();
+  return 0;
 }

--- a/src/kmain.cc
+++ b/src/kmain.cc
@@ -13,6 +13,7 @@
 #include "dma_lab.h"
 #include "mem_lab.h"
 #include "sync_lab.h"
+#include "stack_lab.h"
 
 extern "C" {
   extern char __dma_nc_start[];
@@ -38,6 +39,14 @@ extern "C" {
 
 #ifndef MEM_LAB_MODE
 #define MEM_LAB_MODE 0
+#endif
+
+#ifndef STACK_LAB_MODE
+#define STACK_LAB_MODE 0
+#endif
+
+#if SYNC_LAB_MODE && STACK_LAB_MODE
+#error "Enable only one of SYNC_LAB_MODE or STACK_LAB_MODE"
 #endif
 
 namespace {
@@ -190,6 +199,9 @@ extern "C" void kmain() {
 #endif
   uart_puts("[sync-lab] mode="); uart_print_u64(static_cast<unsigned long long>(SYNC_LAB_MODE)); uart_puts("\n");
   sync_lab_setup(static_cast<unsigned>(SYNC_LAB_MODE));
+#elif STACK_LAB_MODE
+  uart_puts("[stack-lab] mode="); uart_print_u64(static_cast<unsigned long long>(STACK_LAB_MODE)); uart_puts("\n");
+  stack_lab_setup(static_cast<unsigned>(STACK_LAB_MODE));
 #else
   uart_puts("[diag] thread_create a\n");
   Thread* ta = thread_create(a, reinterpret_cast<void*>(0xA), 16 * 1024);

--- a/src/stack_lab.cc
+++ b/src/stack_lab.cc
@@ -1,0 +1,78 @@
+#include "stack_lab.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "arch/cpu_local.h"
+#include "drivers/uart_pl011.h"
+#include "thread.h"
+
+namespace {
+constexpr uintptr_t kGuardPageBytes = 4096u;
+
+constexpr char kHexDigits[] = "0123456789abcdef";
+
+static void puthex64(uint64_t v) {
+  if (!v) { uart_putc('0'); return; }
+  char b[16]; int i = 0;
+  while (v && i < 16) { b[i++] = kHexDigits[v & 0xF]; v >>= 4; }
+  while (i--) uart_putc(b[i]);
+}
+
+static __attribute__((noinline)) void consume_stack(unsigned depth, unsigned limit) {
+  volatile uint8_t buf[256];
+  buf[0] = static_cast<uint8_t>(depth);
+  asm volatile("" ::: "memory");
+  if (depth < limit) {
+    consume_stack(depth + 1u, limit);
+  }
+  asm volatile("" ::: "memory");
+}
+
+static void probe_thread(void*) {
+  uart_puts("[stack-lab] probe start\n");
+
+  auto* cpu = cpu_local();
+  Thread* cur = cpu ? cpu->current_thread : nullptr;
+  if (!cur) {
+    uart_puts("[stack-lab] no current thread?\n");
+    while (1) { asm volatile("wfe"); }
+  }
+
+  uart_puts("[stack-lab] stack_base=0x"); puthex64(reinterpret_cast<uintptr_t>(cur->stack_base));
+  uart_puts(" stack_size="); uart_print_u64(static_cast<unsigned long long>(cur->stack_size));
+  uart_puts("\n");
+
+  // Use a small, known amount of stack and then report the watermark.
+  consume_stack(0u, 8u);
+  size_t used = thread_stack_high_watermark_bytes(cur);
+  uart_puts("[stack-lab] high_watermark_bytes=");
+  uart_print_u64(static_cast<unsigned long long>(used));
+  uart_puts("\n");
+
+  uintptr_t guard = reinterpret_cast<uintptr_t>(cur->stack_base) - kGuardPageBytes;
+  uart_puts("[stack-lab] guard_page=0x"); puthex64(guard); uart_puts("\n");
+  uart_puts("[stack-lab] writing guard page (expected [EXC] DABT)\n");
+
+  *reinterpret_cast<volatile uint8_t*>(guard) = 0x42;
+
+  uart_puts("[stack-lab] BUG: guard page write succeeded\n");
+  while (1) { asm volatile("wfe"); }
+}
+}  // namespace
+
+extern "C" void stack_lab_setup(unsigned mode) {
+  uart_puts("[stack-lab] setup\n");
+  if (mode != 1u) {
+    uart_puts("[stack-lab] unknown mode\n");
+    while (1) { asm volatile("wfe"); }
+  }
+
+  Thread* t = thread_create(probe_thread, nullptr, 8 * 1024);
+  if (!t) {
+    uart_puts("[stack-lab] thread_create failed\n");
+    while (1) { asm volatile("wfe"); }
+  }
+  sched_add(t);
+}
+

--- a/src/sync_lab.cc
+++ b/src/sync_lab.cc
@@ -11,9 +11,20 @@
 namespace {
 mutex g_lock;
 semaphore g_start;
+semaphore g_hold_high;
 
 volatile int g_pi_enabled = 0;
 volatile int g_high_done = 0;
+
+// Deadlock lab state (2 locks / 2 threads + watchdog).
+mutex g_dl_a;
+mutex g_dl_b;
+semaphore g_dl_hold;
+volatile unsigned g_dl_ready = 0;
+volatile int g_dl_done = 0;
+volatile unsigned g_dl_mode = 0;
+Thread* g_dl_t1 = nullptr;
+Thread* g_dl_t2 = nullptr;
 
 static inline void spin(unsigned n) {
   for (volatile unsigned i = 0; i < n; ++i) {
@@ -55,9 +66,9 @@ static void high_thread(void*) {
   mutex_unlock(&g_lock);
   uart_puts("[sync-lab] H done\n");
 
-  while (1) {
-    asm volatile("wfe");
-  }
+  // In a strict priority scheduler, H would otherwise remain runnable and
+  // starve M from printing the final PASS line. Block H permanently.
+  sem_down(&g_hold_high);
 }
 
 static void medium_thread(void*) {
@@ -86,36 +97,242 @@ static void medium_thread(void*) {
     asm volatile("wfe");
   }
 }
+
+static void dl_lock_two_ordered(mutex* a, mutex* b) {
+  if (!a || !b) return;
+  if (a == b) {
+    mutex_lock(a);
+    return;
+  }
+  if (reinterpret_cast<uintptr_t>(a) < reinterpret_cast<uintptr_t>(b)) {
+    mutex_lock(a);
+    mutex_lock(b);
+  } else {
+    mutex_lock(b);
+    mutex_lock(a);
+  }
+}
+
+static void dl_unlock_two_ordered(mutex* a, mutex* b) {
+  if (!a || !b) return;
+  if (a == b) {
+    mutex_unlock(a);
+    return;
+  }
+  // Unlock in reverse order for symmetry.
+  if (reinterpret_cast<uintptr_t>(a) < reinterpret_cast<uintptr_t>(b)) {
+    mutex_unlock(b);
+    mutex_unlock(a);
+  } else {
+    mutex_unlock(a);
+    mutex_unlock(b);
+  }
+}
+
+static void dl_lock_two_trylock_backoff(mutex* first, mutex* second, unsigned backoff_base) {
+  unsigned attempt = 0;
+  for (;;) {
+    mutex_lock(first);
+    if (mutex_trylock(second) == 0) {
+      return;
+    }
+    mutex_unlock(first);
+
+    // Break symmetry deterministically to avoid livelock.
+    attempt++;
+    spin(backoff_base + (attempt * 2000u));
+    thread_yield();
+  }
+}
+
+static void deadlock_worker(void* arg) {
+  const unsigned tid = static_cast<unsigned>(reinterpret_cast<uintptr_t>(arg));
+  uart_puts("[deadlock-lab] T"); uart_print_u64(tid); uart_puts(" start\n");
+
+  mutex* first = (tid == 1) ? &g_dl_a : &g_dl_b;
+  mutex* second = (tid == 1) ? &g_dl_b : &g_dl_a;
+
+  if (g_dl_mode == 2u) {
+    // Naive AB/BA acquisition: expected to deadlock.
+    mutex_lock(first);
+    uart_puts("[deadlock-lab] T"); uart_print_u64(tid); uart_puts(" locked first\n");
+    preempt_disable();
+    g_dl_ready++;
+    preempt_enable();
+    while (g_dl_ready < 2u) {
+      spin(20000);
+      thread_yield();
+    }
+    uart_puts("[deadlock-lab] T"); uart_print_u64(tid); uart_puts(" locking second...\n");
+    mutex_lock(second);
+    uart_puts("[deadlock-lab] BUG: acquired second (unexpected)\n");
+  } else if (g_dl_mode == 3u) {
+    // Fix #1: global lock ordering.
+    dl_lock_two_ordered(&g_dl_a, &g_dl_b);
+    uart_puts("[deadlock-lab] T"); uart_print_u64(tid); uart_puts(" acquired both (ordered)\n");
+    dl_unlock_two_ordered(&g_dl_a, &g_dl_b);
+    preempt_disable();
+    g_dl_done++;
+    preempt_enable();
+    sem_down(&g_dl_hold);
+  } else if (g_dl_mode == 4u) {
+    // Fix #2: trylock + backoff.
+    const unsigned backoff = (tid == 1) ? 3000u : 7000u;
+    dl_lock_two_trylock_backoff(first, second, backoff);
+    uart_puts("[deadlock-lab] T"); uart_print_u64(tid); uart_puts(" acquired both (trylock)\n");
+    mutex_unlock(second);
+    mutex_unlock(first);
+    preempt_disable();
+    g_dl_done++;
+    preempt_enable();
+    sem_down(&g_dl_hold);
+  } else if (g_dl_mode == 5u) {
+    // Fix #3: simplified lockdep (detected inside mutex_lock).
+    mutex_lock(first);
+    uart_puts("[deadlock-lab] T"); uart_print_u64(tid); uart_puts(" locked first\n");
+    preempt_disable();
+    g_dl_ready++;
+    preempt_enable();
+    while (g_dl_ready < 2u) {
+      spin(20000);
+      thread_yield();
+    }
+    uart_puts("[deadlock-lab] T"); uart_print_u64(tid); uart_puts(" locking second...\n");
+    mutex_lock(second);  // Expected to trigger lockdep and halt.
+    uart_puts("[deadlock-lab] BUG: lockdep did not trigger\n");
+  } else {
+    uart_puts("[deadlock-lab] invalid mode\n");
+  }
+
+  while (1) {
+    asm volatile("wfe");
+  }
+}
+
+static int dl_deadlock_observed() {
+  if (!g_dl_t1 || !g_dl_t2) return 0;
+  if (g_dl_t1->state != 1 || g_dl_t2->state != 1) return 0;  // both BLOCKED
+  if (g_dl_a.owner != g_dl_t1 || g_dl_b.owner != g_dl_t2) return 0;
+  if (g_dl_t1->waiting_on != &g_dl_b) return 0;
+  if (g_dl_t2->waiting_on != &g_dl_a) return 0;
+  return 1;
+}
+
+static void deadlock_watchdog(void*) {
+  uart_puts("[deadlock-lab] watchdog start\n");
+  uint64_t t0 = cpu_local()->ticks;
+  bool printed = false;
+
+  for (;;) {
+    const uint64_t dt = cpu_local()->ticks - t0;
+
+    if (g_dl_mode == 2u) {
+      if (dl_deadlock_observed()) {
+        uart_puts("[deadlock-lab] deadlock observed (AB/BA)\n");
+        uart_puts("[deadlock-lab] fixes: lock ordering | trylock+backoff | lockdep\n");
+        break;
+      }
+      if (!printed && dt >= 50) {
+        uart_puts("[deadlock-lab] waiting for deadlock...\n");
+        printed = true;
+      }
+      if (dt >= 200) {
+        uart_puts("[deadlock-lab] FAIL: deadlock not observed (timing?)\n");
+        break;
+      }
+    } else if (g_dl_mode == 3u || g_dl_mode == 4u) {
+      if (g_dl_done >= 2) {
+        uart_puts("[deadlock-lab] result PASS\n");
+        break;
+      }
+      if (dt >= 200) {
+        uart_puts("[deadlock-lab] FAIL: timeout waiting for completion\n");
+        break;
+      }
+    } else {
+      // Mode 5 halts inside lockdep on success; nothing to do here.
+      if (dt >= 200) {
+        uart_puts("[deadlock-lab] FAIL: lockdep did not trigger\n");
+        break;
+      }
+    }
+
+    spin(20000);
+    thread_yield();
+  }
+
+  while (1) {
+    asm volatile("wfe");
+  }
+}
 }  // namespace
 
 extern "C" void sync_lab_setup(unsigned mode) {
-  (void)mode;
+  if (mode == 1u) {
+    uart_puts("[sync-lab] setup\n");
+    g_pi_enabled = 0;
+    g_high_done = 0;
 
-  uart_puts("[sync-lab] setup\n");
-  g_pi_enabled = 0;
-  g_high_done = 0;
+    mutex_init(&g_lock);
+    mutex_set_pi_enabled(&g_lock, 0);
+    sem_init(&g_start, 0);
+    sem_init(&g_hold_high, 0);
 
-  mutex_init(&g_lock);
-  mutex_set_pi_enabled(&g_lock, 0);
-  sem_init(&g_start, 0);
+    // Classic 3-thread priority inversion:
+    // - L (low): holds mutex
+    // - H (high): blocks on mutex
+    // - M (medium): runs, starving L until PI boosts L
+    Thread* l = thread_create_prio(low_thread, nullptr, 16 * 1024, /*prio=*/5);
+    Thread* m = thread_create_prio(medium_thread, nullptr, 16 * 1024, /*prio=*/10);
+    Thread* h = thread_create_prio(high_thread, nullptr, 16 * 1024, /*prio=*/20);
 
-  // Classic 3-thread priority inversion:
-  // - L (low): holds mutex
-  // - H (high): blocks on mutex
-  // - M (medium): runs, starving L until PI boosts L
-  Thread* l = thread_create_prio(low_thread, nullptr, 16 * 1024, /*prio=*/5);
-  Thread* m = thread_create_prio(medium_thread, nullptr, 16 * 1024, /*prio=*/10);
-  Thread* h = thread_create_prio(high_thread, nullptr, 16 * 1024, /*prio=*/20);
-
-  if (!l || !m || !h) {
-    uart_puts("[sync-lab] thread_create failed\n");
-    while (1) {
-      asm volatile("wfe");
+    if (!l || !m || !h) {
+      uart_puts("[sync-lab] thread_create failed\n");
+      while (1) {
+        asm volatile("wfe");
+      }
     }
+
+    sched_add(l);
+    sched_add(m);
+    sched_add(h);
+    return;
   }
 
-  sched_add(l);
-  sched_add(m);
-  sched_add(h);
-}
+  if (mode >= 2u && mode <= 5u) {
+    uart_puts("[deadlock-lab] setup\n");
+    g_dl_mode = mode;
+    g_dl_done = 0;
+    g_dl_ready = 0;
+    g_dl_t1 = nullptr;
+    g_dl_t2 = nullptr;
 
+    mutex_init(&g_dl_a);
+    mutex_init(&g_dl_b);
+    sem_init(&g_dl_hold, 0);
+
+    // Two workers intentionally acquire locks in opposite order. A watchdog
+    // thread guarantees there is always at least one runnable thread.
+    g_dl_t1 = thread_create_prio(deadlock_worker, reinterpret_cast<void*>(1), 16 * 1024, /*prio=*/20);
+    g_dl_t2 = thread_create_prio(deadlock_worker, reinterpret_cast<void*>(2), 16 * 1024, /*prio=*/20);
+    Thread* w = thread_create_prio(deadlock_watchdog, nullptr, 16 * 1024, /*prio=*/5);
+
+    if (!g_dl_t1 || !g_dl_t2 || !w) {
+      uart_puts("[deadlock-lab] thread_create failed\n");
+      while (1) {
+        asm volatile("wfe");
+      }
+    }
+
+    sched_add(g_dl_t1);
+    sched_add(g_dl_t2);
+    sched_add(w);
+    return;
+  }
+
+  uart_puts("[sync-lab] unknown mode\n");
+  uart_puts("[sync-lab] modes: 1=pi, 2=deadlock, 3=ordering, 4=trylock, 5=lockdep\n");
+  while (1) {
+    asm volatile("wfe");
+  }
+}


### PR DESCRIPTION
- Add deadlock lab suite (2 locks / 2 threads) with 3 fixes under SYNC_LAB_MODE=2..5:
    - 2: reproduce AB/BA deadlock + watchdog detects it
    - 3: fix via global lock ordering
    - 4: fix via mutex_trylock() + backoff
    - 5: fix via simplified lockdep (cycle detection inside mutex_lock)
- Add mutex_trylock() API and track Thread::waiting_on for lockdep/deadlock detection.
- Make fixed-size pool allocator “real”: allocate Thread objects from a mem_pool initialized in sched_init() (predictable O(1), no external fragmentation).
- Add MMU-backed stack guard pages:
    - New mmu_guard_page() and mmu_enabled(); thread stacks reserve an unmapped 4 KiB page below stack_base.
    - New STACK_LAB_MODE=1 (stack_lab_run.sh) intentionally touches the guard page and expects [EXC] (DABT) to prove it’s active.
- Add lab runners:
    - mem_lab_run.sh: validates [mem-lab][pool] internal_frag_pct=..., [mem-lab][malloc] external_frag_pct=..., big alloc FAILED (fragmentation)
    - sync_lab_run.sh: validates PI/deadlock outputs per mode
    - stack_lab_run.sh: validates guard-page fault
- Keep default CI smoke stable:
    - smoke_run.sh now forces MEM_LAB_MODE=0, SYNC_LAB_MODE=0, STACK_LAB_MODE=0, DMA_LAB_MODE=0, SCHED_POLICY=RR to prevent env-var contamination.
- Docs updated:
    - README.md adds knobs + how to run labs
    - memory.md documents pool adoption + guard-page stack lab

**How to run**

- Default: smoke_run.sh
- Memory lab: mem_lab_run.sh
- PI lab: sync_lab_run.sh
- Deadlock labs: sync_lab_run.sh
- Stack guard-page lab: stack_lab_run.sh